### PR TITLE
Enable editing while Coq runs asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Change Log
+
+## Unreleased [master]
+
+## [1.0.0]
+
+### Added
+- Use '+channel' feature (Vim >=8.0 only) to enable asynchronous communication
+  with Coq instead of blocking.
+  See [README.md](https://github.com/whonore/Coqtail/blob/v1.0.0/README.md) for
+  more information.
+- Use a synchronous fallback for Vim 7.4.
+- CoqInterrupt command that forwards SIGINT to the Coq process.
+- CoqRestorePanel command that re-opens Goal and Info panels in their original
+  positions.
+- Changelog, begin using semantic (more or less) versioning.
+
+### Changed
+- No longer crash if Goal or Info panels are closed.
+- Clean up and refactor Vim and Python scripts>
+
+### Removed
+- Dependency on `vim` Python module.
+- Dependency on [vimbufsync].
+- CoqMakeMatch command.
+  It wasn't well thought out and didn't seem very useful.
+  Please open an issue if you'd like it to be re-added.
+
+### Fixed
+
+## [pre-async]
+
+### Added
+- Support Vim >=7.4.
+- Support Python 2 and 3.
+- Support Coq 8.4-8.11.
+- Interactive Coq proofs similar to CoqIDE/Proof General.
+- Support multiple open Coq buffers simultaneously.
+- Coq syntax highlighting.
+- Coq automatic indentation.
+- Interoperability with [matchup] and [endwise].
+
+[master]: https://github.com/whonore/Coqtail
+[1.0.0]: https://github.com/whonore/Coqtail/tree/v1.0.0
+[pre-async]: https://github.com/whonore/Coqtail/tree/pre-async
+[vimbufsync]: https://github.com/let-def/vimbufsync
+[matchup]: https://github.com/andymass/vim-matchup
+[endwise]: https://github.com/tpope/vim-endwise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,13 @@
 ## [1.0.0]
 
 ### Added
-- Use `+chnnel` feature (Vim >=8.0 only) to enable non-blocking communication
+- Use `+channel` feature (Vim >=8.0 only) to enable non-blocking communication
   with Coq.
 - Use a synchronous fallback for Vim 7.4.
 - `CoqInterrupt` command that forwards `SIGINT` to the Coq process.
 - `CoqRestorePanel` command that re-opens the Goal and Info panels in their
   original positions.
 - Changelog, begin using semantic (more or less) versioning.
-
-### Changed
-- No longer crash if Goal or Info panels are closed.
-- Clean up and refactor Vim and Python scripts.
 
 ### Removed
 - Dependency on `vim` Python module.
@@ -26,20 +22,21 @@
   like it to be re-added.
 
 ### Fixed
+- No longer crash if Goal or Info panels are closed.
 
 ## [pre-1.0]
 
 ### Added
-- Support Vim >=7.4.
-- Support Python 2 and 3.
-- Support Coq 8.4-8.11.
 - Interactive Coq proofs similar to CoqIDE/Proof General.
-- Support multiple open Coq buffers simultaneously.
+- Support for Vim >=7.4.
+- Support for Python 2 and 3.
+- Support for Coq 8.4-8.11.
+- Support simultaneous Coq sessions in different buffers.
 - Locate and parse _CoqProject files.
 - Coq syntax highlighting.
 - Coq automatic indentation.
-- Jumping to definitions.
-- Following imports for autocompletion.
+- Allow jumping to definitions.
+- Allow following imports for autocompletion.
 - Support for `:tag` commands (only with `+tagfunc`).
 - Interoperability with [matchup] and [endwise].
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Changelog, begin using semantic (more or less) versioning.
 
 ### Removed
-- Dependency on `vim` Python module.
+- Dependency on `vim` module in Python code.
 - Dependency on [vimbufsync].
 - `CoqMakeMatch` command.
   It wasn't well thought out and didn't seem very useful.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 ### Fixed
 - Commands no longer crash when called while Goal or Info panels are closed.
 
+### Deprecated
+- Python 2 support. See [ycm] if you need help building Vim with Python 3 support.
+
 ## [pre-1.0]
 
 ### Added
@@ -45,3 +48,4 @@
 [vimbufsync]: https://github.com/let-def/vimbufsync
 [matchup]: https://github.com/andymass/vim-matchup
 [endwise]: https://github.com/tpope/vim-endwise
+[ycm]: https://github.com/ycm-core/YouCompleteMe/wiki/Building-Vim-from-source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased [master]
+## Unreleased ([master])
 
 ## [1.0.0]
 
@@ -24,7 +24,7 @@
 - Commands no longer crash when called while Goal or Info panels are closed.
 
 ### Deprecated
-- Python 2 support. See [ycm] if you need help building Vim with Python 3 support.
+- Python 2 support. See [YouCompleteMe] for help building Vim with Python 3 support.
 
 ## [pre-1.0]
 
@@ -48,4 +48,4 @@
 [vimbufsync]: https://github.com/let-def/vimbufsync
 [matchup]: https://github.com/andymass/vim-matchup
 [endwise]: https://github.com/tpope/vim-endwise
-[ycm]: https://github.com/ycm-core/YouCompleteMe/wiki/Building-Vim-from-source
+[YouCompleteMe]: https://github.com/ycm-core/YouCompleteMe/wiki/Building-Vim-from-source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@
 ## [1.0.0]
 
 ### Added
-- Use `+channel` feature (Vim >=8.0 only) to enable non-blocking communication
-  with Coq.
-- Use a synchronous fallback for Vim 7.4.
+- Non-blocking communication with Coq using the `+channel` feature (Vim >=8.0 only).
+- A synchronous fallback for Vim 7.4.
 - `CoqInterrupt` command that forwards `SIGINT` to the Coq process.
-- `CoqRestorePanel` command that re-opens the Goal and Info panels in their
+- `CoqRestorePanels` command that re-opens the Goal and Info panels in their
   original positions.
-- Changelog, begin using semantic (more or less) versioning.
+- This changelog. Begin using semantic (more or less) versioning.
 
 ### Removed
 - Dependency on `vim` module in Python code.
@@ -22,21 +21,21 @@
   like it to be re-added.
 
 ### Fixed
-- No longer crash if Goal or Info panels are closed.
+- Commands no longer crash when called while Goal or Info panels are closed.
 
 ## [pre-1.0]
 
 ### Added
-- Interactive Coq proofs similar to CoqIDE/Proof General.
+- Interactive Coq interface similar to CoqIDE/Proof General.
 - Support for Vim >=7.4.
 - Support for Python 2 and 3.
 - Support for Coq 8.4-8.11.
-- Support simultaneous Coq sessions in different buffers.
-- Locate and parse _CoqProject files.
+- Support for simultaneous Coq sessions in different buffers.
+- Locating and parsing of _CoqProject files.
 - Coq syntax highlighting.
 - Coq automatic indentation.
-- Allow jumping to definitions.
-- Allow following imports for autocompletion.
+- `CoqGotoDef` command for jumping to definitions.
+- `includeexpr` for following imports during autocompletion.
 - Support for `:tag` commands (only with `+tagfunc`).
 - Interoperability with [matchup] and [endwise].
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,30 +5,29 @@
 ## [1.0.0]
 
 ### Added
-- Use '+channel' feature (Vim >=8.0 only) to enable asynchronous communication
-  with Coq instead of blocking.
-  See [README.md](https://github.com/whonore/Coqtail/blob/v1.0.0/README.md) for
-  more information.
+- Use `+chnnel` feature (Vim >=8.0 only) to enable non-blocking communication
+  with Coq.
 - Use a synchronous fallback for Vim 7.4.
-- CoqInterrupt command that forwards SIGINT to the Coq process.
-- CoqRestorePanel command that re-opens Goal and Info panels in their original
-  positions.
+- `CoqInterrupt` command that forwards `SIGINT` to the Coq process.
+- `CoqRestorePanel` command that re-opens the Goal and Info panels in their
+  original positions.
 - Changelog, begin using semantic (more or less) versioning.
 
 ### Changed
 - No longer crash if Goal or Info panels are closed.
-- Clean up and refactor Vim and Python scripts>
+- Clean up and refactor Vim and Python scripts.
 
 ### Removed
 - Dependency on `vim` Python module.
 - Dependency on [vimbufsync].
-- CoqMakeMatch command.
+- `CoqMakeMatch` command.
   It wasn't well thought out and didn't seem very useful.
-  Please open an issue if you'd like it to be re-added.
+  Please [open an issue](https://github.com/whonore/Coqtail/issues) if you'd
+  like it to be re-added.
 
 ### Fixed
 
-## [pre-async]
+## [pre-1.0]
 
 ### Added
 - Support Vim >=7.4.
@@ -36,13 +35,17 @@
 - Support Coq 8.4-8.11.
 - Interactive Coq proofs similar to CoqIDE/Proof General.
 - Support multiple open Coq buffers simultaneously.
+- Locate and parse _CoqProject files.
 - Coq syntax highlighting.
 - Coq automatic indentation.
+- Jumping to definitions.
+- Following imports for autocompletion.
+- Support for `:tag` commands (only with `+tagfunc`).
 - Interoperability with [matchup] and [endwise].
 
 [master]: https://github.com/whonore/Coqtail
 [1.0.0]: https://github.com/whonore/Coqtail/tree/v1.0.0
-[pre-async]: https://github.com/whonore/Coqtail/tree/pre-async
+[pre-1.0]: https://github.com/whonore/Coqtail/tree/pre-1.0
 [vimbufsync]: https://github.com/let-def/vimbufsync
 [matchup]: https://github.com/andymass/vim-matchup
 [endwise]: https://github.com/tpope/vim-endwise

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ vim +PlugInstall +qa
 
 Requirements:
 - Vim compiled with either `+python`<sup>[1](#python2)</sup> or `+python3`
-- For syntax highlighting, Vim configuration options `filetype plugin indent on` and `syntax on` (e.g. in `.vimrc`)
+- Vim configuration options `filetype plugin on`, and optionally `filetype indent on` and `syntax on` (e.g. in `.vimrc`)
 - [Coq 8.4 - 8.11](https://coq.inria.fr/download)
 
 Newer versions of Coq have not yet been tested, but should still work as long as

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Coqtail provides the following commands (see `:help coqtail` for more details):
 | **Starting and Stopping** | |
 | `CoqStart` | `<leader>cc` | Launch Coqtail for the current buffer. |
 | `CoqStop` | `<leader>cq` | Quit Coqtail for the current buffer. |
+| `CoqInterrupt` | `CTRL-C` | Send SIGINT to `coqtop`. |
 | **Movement** | |
 | `{n}CoqNext` | `<leader>cj` | Check the next `n` (1 by default) sentences with Coq. |
 | `{n}CoqUndo` | `<leader>ck` | Step back `n` (1 by default) sentences. |
@@ -93,6 +94,8 @@ The mappings shown above are set by default, but you can disable them all and
 define your own by setting `g:coqtail_nomap = 1` in your .vimrc.
 Alternatively, you can choose to only remap specific commands and the defaults
 will still be used for the rest.
+For example, set `map <leader>ci <Plug>CoqInterrupt` in your .vimrc to not
+hijack `CTRL-C`.
 
 By default Coqtail will use the `coqtop` or `coqtop.opt` on your `PATH`.
 You can tell it to search instead in a specific directory by setting

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ or [ProofGeneral](https://proofgeneral.github.io/).
 
 It supports:
 - [Coq 8.4 - 8.11](https://coq.inria.fr/download)
-- Having multiple Coq buffers open
 - Python 2<sup>[1](#python2)</sup> and 3
+- Vim 7.4 - 8.2
+- Multiple Coq sessions in different buffers
 
 ## Installation and Requirements
 
@@ -47,10 +48,9 @@ Plug 'whonore/Coqtail' | Plug 'let-def/vimbufsync' (add this line in .vimrc)
 vim +PlugInstall +qa
 ```
 
-Coqtail requires:
+Requirements:
 - Vim compiled with either `+python`<sup>[1](#python2)</sup> or `+python3`
-- Vim configuration options `filetype plugin indent on` and `syntax on` (e.g. in `.vimrc`)
-- [vimbufsync](https://github.com/let-def/vimbufsync)
+- For syntax highlighting, Vim configuration options `filetype plugin indent on` and `syntax on` (e.g. in `.vimrc`)
 - [Coq 8.4 - 8.11](https://coq.inria.fr/download)
 
 Newer versions of Coq have not yet been tested, but should still work as long as
@@ -90,11 +90,14 @@ Coqtail provides the following commands (see `:help coqtail` for more details):
 | `CoqGotoGoalPrev` | `g[` | Scroll the goal panel to the start of the previous goal. |
 | `CoqGotoGoalPrev!` | `G[` | Scroll the goal panel to the end of the previous goal. |
 
+
+## Configuration
+
 The mappings shown above are set by default, but you can disable them all and
-define your own by setting `g:coqtail_nomap = 1` in your .vimrc.
-Alternatively, you can choose to only remap specific commands and the defaults
-will still be used for the rest.
-For example, set `map <leader>ci <Plug>CoqInterrupt` in your .vimrc to not
+define your own by setting `g:coqtail_nomap = 1` in your `.vimrc`.
+Alternatively, you can remap specific commands and the defaults will still be
+used for the rest.
+For example, set `map <leader>ci <Plug>CoqInterrupt` in your `.vimrc` to not
 hijack `CTRL-C`.
 
 By default Coqtail will use the `coqtop` or `coqtop.opt` on your `PATH`.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Coqtail provides the following commands (see `:help coqtail` for more details):
 | `Coq Print <arg>` | `<leader>cp` | Show the definition of `<arg>`. |
 | `Coq Locate <arg>` | `<leader>cf` | Show where `<arg>` is defined. |
 | `Coq Search <args>` | `<leader>cs` | Show theorems about `<args>`. |
-| **Goal Focusing** | |
+| **Panel Management** | |
+| `CoqRestorePanels` | `<leader>cr` | Re-open the goal and info panels. |
 | `{n}CoqGotoGoal` | `<leader>cgg` | Scroll the goal panel to the start of the `n`th goal (defaults to 1). Number of lines shown is controlled by `g:coqtail_goal_lines`. |
 | `{n}CoqGotoGoal!` | `<leader>cGG` | Scroll the goal panel to the end of the `n`th goal. |
 | `CoqGotoGoalNext` | `g]` | Scroll the goal panel to the start of the next goal. |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ As a
 [vim package](https://vimhelp.org/repeat.txt.html#packages):
 ```sh
 mkdir -p ~/.vim/pack/coq/start
-git clone https://github.com/let-def/vimbufsync.git ~/.vim/pack/coq/start/vimbufsync
 git clone https://github.com/whonore/Coqtail.git ~/.vim/pack/coq/start/Coqtail
 vim +helptags\ ~/.vim/pack/coq/start/Coqtail/doc +q
 ```
@@ -29,7 +28,6 @@ vim +helptags\ ~/.vim/pack/coq/start/Coqtail/doc +q
 Using
 [pathogen](https://github.com/tpope/vim-pathogen):
 ```sh
-git clone https://github.com/let-def/vimbufsync.git ~/.vim/bundle/vimbufsync
 git clone https://github.com/whonore/Coqtail.git ~/.vim/bundle/Coqtail
 vim +Helptags +q
 ```
@@ -37,14 +35,14 @@ vim +Helptags +q
 Using
 [Vundle](https://github.com/VundleVim/Vundle.vim):
 ```sh
-Plugin 'whonore/Coqtail' | Plugin 'let-def/vimbufsync' (add this line in .vimrc)
+Plugin 'whonore/Coqtail' (add this line in .vimrc)
 vim +PluginInstall +qa
 ```
 
 Using
 [VimPlug](https://github.com/junegunn/vim-plug):
 ```sh
-Plug 'whonore/Coqtail' | Plug 'let-def/vimbufsync' (add this line in .vimrc)
+Plug 'whonore/Coqtail' (add this line in .vimrc)
 vim +PlugInstall +qa
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ versions of Vincent Aravantinos'
 These scripts are used by default but can be disabled by setting
 `g:coqtail_nosyntax = 1` and `g:coqtail_noindent = 1` respectively.
 
-See `:help coqtail-configuration` for other configuration variables.
+See `:help coqtail-configuration` for more configuration variables.
 
 ## Vim Plugin Interoperability
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ vim +PlugInstall +qa
 
 Requirements:
 - Vim compiled with either `+python`<sup>[1](#python2)</sup> or `+python3`
-- Vim configuration options `filetype plugin on`, and optionally `filetype indent on` and `syntax on` (e.g. in `.vimrc`)
+- Vim configuration options `filetype plugin on`, and optionally
+  `filetype indent on` and `syntax on` (e.g. in `.vimrc`)
 - [Coq 8.4 - 8.11](https://coq.inria.fr/download)
 
-Newer versions of Coq have not yet been tested, but should still work as long as
-there are no major changes made to the XML protocol Coqtail uses to communicate
-with `coqtop`.
+Newer versions of Coq have not yet been tested, but should still work as long
+as there are no major changes made to the XML protocol Coqtail uses to
+communicate with `coqtop`.
 
 ## Usage
 
@@ -90,7 +91,6 @@ Coqtail provides the following commands (see `:help coqtail` for more details):
 | `CoqGotoGoalPrev` | `g[` | Scroll the goal panel to the start of the previous goal. |
 | `CoqGotoGoalPrev!` | `G[` | Scroll the goal panel to the end of the previous goal. |
 
-
 ## Configuration
 
 The mappings shown above are set by default, but you can disable them all and
@@ -102,8 +102,8 @@ hijack `CTRL-C`.
 
 By default Coqtail will use the `coqtop` or `coqtop.opt` on your `PATH`.
 You can tell it to search instead in a specific directory by setting
-`b:coqtail_coq_path` before calling `CoqStart`. To set this option globally use
-`g:coqtail_coq_path`.
+`b:coqtail_coq_path` before calling `CoqStart`.
+To set this option globally use `g:coqtail_coq_path`.
 
 Coqtail also comes with an ftdetect script for Coq, as well as modified
 versions of Vincent Aravantinos'
@@ -123,9 +123,9 @@ text with `%` using the
 
 ### Automatically closing blocks
 
-Coqtail defines patterns to enable automatic insertion of the appropriate
-`End` command for code blocks such as `Section`s, `Module`s, and `match`
-expressions with [endwise](https://github.com/tpope/vim-endwise).
+Coqtail defines patterns to enable automatic insertion of the appropriate `End`
+command for code blocks such as `Section`s, `Module`s, and `match` expressions
+with [endwise](https://github.com/tpope/vim-endwise).
 
 ## Thanks
 
@@ -136,4 +136,8 @@ Parts of Coqtail were originally inspired by/adapted from
 ---
 
 #### <a name="python2">Python 2 Support</a>
-Because Python 2 has reached its [end-of-life](https://pythonclock.org/) and supporting it alongside Python 3 makes it difficult to improve and maintain the code, Coqtail will drop support for Python 2 in the near future. At that time a stable version will be tagged and all future versions will be Python 3-only.
+Because Python 2 has reached its [end-of-life](https://pythonclock.org/) and
+supporting it alongside Python 3 makes it difficult to improve and maintain the
+code, Coqtail will drop support for Python 2 in the near future.
+At that time a stable version will be tagged and all future versions will be
+Python 3-only.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@
 
 ## Interactive Coq Proofs in Vim
 
-Coqtail enables interactive Coq proof development in Vim similar to
-[CoqIDE](https://coq.inria.fr/refman/practical-tools/coqide.html)
-or [ProofGeneral](https://proofgeneral.github.io/).
+Coqtail enables interactive Coq proof development in Vim similar to [CoqIDE] or
+[ProofGeneral].
 
 It supports:
-- [Coq 8.4 - 8.11](https://coq.inria.fr/download)
+- [Coq 8.4 - 8.11]
 - Python 2<sup>[1](#python2)</sup> and 3
 - Vim >=7.4 (Neovim coming soon)
 - Simultaneous Coq sessions in different buffers
@@ -18,30 +17,26 @@ It supports:
 
 ## Installation and Requirements
 
-As a
-[vim package](https://vimhelp.org/repeat.txt.html#packages):
+As a [vim package]:
 ```sh
 mkdir -p ~/.vim/pack/coq/start
 git clone https://github.com/whonore/Coqtail.git ~/.vim/pack/coq/start/Coqtail
 vim +helptags\ ~/.vim/pack/coq/start/Coqtail/doc +q
 ```
 
-Using
-[pathogen](https://github.com/tpope/vim-pathogen):
+Using [pathogen]:
 ```sh
 git clone https://github.com/whonore/Coqtail.git ~/.vim/bundle/Coqtail
 vim +Helptags +q
 ```
 
-Using
-[Vundle](https://github.com/VundleVim/Vundle.vim):
+Using [Vundle]:
 ```sh
 Plugin 'whonore/Coqtail' (add this line in .vimrc)
 vim +PluginInstall +qa
 ```
 
-Using
-[VimPlug](https://github.com/junegunn/vim-plug):
+Using [VimPlug]:
 ```sh
 Plug 'whonore/Coqtail' (add this line in .vimrc)
 vim +PlugInstall +qa
@@ -51,7 +46,7 @@ Requirements:
 - Vim compiled with either `+python`<sup>[1](#python2)</sup> or `+python3`
 - Vim configuration options `filetype plugin on`, and optionally
   `filetype indent on` and `syntax on` (e.g. in `.vimrc`)
-- [Coq 8.4 - 8.11](https://coq.inria.fr/download)
+- [Coq 8.4 - 8.11]
 
 Newer versions of Coq have not yet been tested, but should still work as long
 as there are no major changes made to the XML protocol Coqtail uses to
@@ -103,9 +98,7 @@ You can tell it to instead search in a directory by setting
 Use `g:coqtail_coq_path` to set this option globally.
 
 Coqtail also comes with an ftdetect script for Coq, as well as modified
-versions of Vincent Aravantinos'
-[syntax](http://www.vim.org/scripts/script.php?script_id=2063) and
-[indent](http://www.vim.org/scripts/script.php?script_id=2079) scripts for Coq.
+versions of Vincent Aravantinos' [syntax] and [indent] scripts for Coq.
 These scripts are used by default but can be disabled by setting
 `g:coqtail_nosyntax = 1` and `g:coqtail_noindent = 1` respectively.
 
@@ -116,21 +109,18 @@ See `:help coqtail-configuration` for more configuration variables.
 ### Jumping between matches
 
 Coqtail defines `b:match_words` patterns to support jumping between matched
-text with `%` using the
-[matchup](https://github.com/andymass/vim-matchup) or
-[matchit](http://ftp.vim.org/pub/vim/runtime/macros/matchit.txt) plugins.
+text with `%` using the [matchup] or [matchit] plugins.
 
 ### Automatically closing blocks
 
 Coqtail defines patterns to enable automatic insertion of the appropriate `End`
 command for code blocks such as `Section`s, `Module`s, and `match` expressions
-with [endwise](https://github.com/tpope/vim-endwise).
+with [endwise].
 
 ## Thanks
 
-Parts of Coqtail were originally inspired by/adapted from
-[Coquille](https://github.com/the-lambda-church/coquille)
-(MIT License, Copyright (c) 2013, Thomas Refis).
+Parts of Coqtail were originally inspired by/adapted from [Coquille] (MIT
+License, Copyright (c) 2013, Thomas Refis).
 
 ---
 
@@ -140,3 +130,19 @@ supporting it alongside Python 3 makes it difficult to improve and maintain the
 code, Coqtail will drop support for Python 2 in the near future.
 At that time a stable version will be tagged and all future versions will be
 Python 3-only.
+See [YouCompleteMe] for help building Vim with Python 3 support.
+
+[Coq 8.4 - 8.11]: https://coq.inria.fr/download
+[CoqIDE]: https://coq.inria.fr/refman/practical-tools/coqide.html
+[ProofGeneral]: https://proofgeneral.github.io/
+[vim package]: https://vimhelp.org/repeat.txt.html#packages
+[pathogen]: https://github.com/tpope/vim-pathogen
+[Vundle]: https://github.com/VundleVim/Vundle.vim
+[VimPlug]: https://github.com/junegunn/vim-plug
+[syntax]: http://www.vim.org/scripts/script.php?script_id=2063
+[indent]: http://www.vim.org/scripts/script.php?script_id=2079
+[matchup]: https://github.com/andymass/vim-matchup
+[matchit]: http://ftp.vim.org/pub/vim/runtime/macros/matchit.txt
+[endwise]: https://github.com/tpope/vim-endwise
+[Coquille]: https://github.com/the-lambda-church/coquille
+[YouCompleteMe]: https://github.com/ycm-core/YouCompleteMe/wiki/Building-Vim-from-source

--- a/README.md
+++ b/README.md
@@ -95,13 +95,12 @@ Coqtail provides the following commands (see `:help coqtail` for more details):
 The mappings above are set by default, but you can disable them all and define
 your own by setting `g:coqtail_nomap = 1` in your `.vimrc`.
 Alternatively, you can keep the defaults but remap specific commands.
-For example, set `map <leader>ci <Plug>CoqInterrupt` in your `.vimrc` to not
-hijack `CTRL-C`.
+For example, use `map <leader>ci <Plug>CoqInterrupt` to avoid hijacking `CTRL-C`.
 
-By default Coqtail will use the `coqtop/coqidetop` or `coqtop.opt` on your `PATH`.
-You can tell it to search instead in a specific directory by setting
+By default Coqtail uses the `coq(ide)top(.opt)` found on your `PATH`.
+You can tell it to instead search in a directory by setting
 `b:coqtail_coq_path` before calling `CoqStart`.
-To set this option globally use `g:coqtail_coq_path`.
+Use `g:coqtail_coq_path` to set this option globally.
 
 Coqtail also comes with an ftdetect script for Coq, as well as modified
 versions of Vincent Aravantinos'

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ or [ProofGeneral](https://proofgeneral.github.io/).
 It supports:
 - [Coq 8.4 - 8.11](https://coq.inria.fr/download)
 - Python 2<sup>[1](#python2)</sup> and 3
-- Vim 7.4 - 8.2
-- Multiple Coq sessions in different buffers
+- Vim >=7.4 (Neovim coming soon)
+- Simultaneous Coq sessions in different buffers
+- Non-blocking communication between Vim and Coq (Vim >=8.0 only)
 
 ## Installation and Requirements
 
@@ -63,16 +64,16 @@ Coqtail provides the following commands (see `:help coqtail` for more details):
 | Command | Mapping | Description |
 |---|---|---|
 | **Starting and Stopping** | |
-| `CoqStart` | `<leader>cc` | Launch Coqtail for the current buffer. |
-| `CoqStop` | `<leader>cq` | Quit Coqtail for the current buffer. |
+| `CoqStart` | `<leader>cc` | Launch Coqtail in the current buffer. |
+| `CoqStop` | `<leader>cq` | Quit Coqtail in the current buffer. |
 | `CoqInterrupt` | `CTRL-C` | Send SIGINT to `coqtop`. |
 | **Movement** | |
-| `{n}CoqNext` | `<leader>cj` | Check the next `n` (1 by default) sentences with Coq. |
+| `{n}CoqNext` | `<leader>cj` | Send the next `n` (1 by default) sentences to Coq. |
 | `{n}CoqUndo` | `<leader>ck` | Step back `n` (1 by default) sentences. |
-| `{n}CoqToLine` | `<leader>cl` | Check/rewind all sentences up to line `n` (cursor position by default). `n` can also be `$` to check the entire buffer.|
-| `CoqToTop` | `<leader>cT` | Rewind to the beginning of the file. Similar to `1CoqToLine`, but `CoqToLine` only rewinds to the end of the line. |
+| `{n}CoqToLine` | `<leader>cl` | Send/rewind all sentences up to line `n` (cursor position by default). `n` can also be `$` to check the entire buffer. |
+| `CoqToTop` | `<leader>cT` | Rewind to the beginning of the file. |
 | `CoqJumpToEnd` | `<leader>cG` | Move the cursor to the end of the checked region. |
-| `CoqGotoDef[!] <arg>` | `<leader>cg` | Populate the quickfix list with possible locations of the definition of `<arg>` and try to jump to the first one. If your Vim supports `'tagfunc'` you can just use `CTRL-]`, `:tag`, and friends instead. |
+| `CoqGotoDef[!] <arg>` | `<leader>cg` | Populate the quickfix list with possible locations of the definition of `<arg>` and try to jump to the first one. If your Vim supports `'tagfunc'` you can also use `CTRL-]`, `:tag`, and friends. |
 | **Queries** | |
 | `Coq <args>` | | Send arbitrary queries to Coq (e.g. `Check`, `About`, `Print`, etc.). |
 | `Coq Check <arg>` | `<leader>ch` | Show the type of `<arg>` (the mapping will use the term under the cursor). |
@@ -81,24 +82,23 @@ Coqtail provides the following commands (see `:help coqtail` for more details):
 | `Coq Locate <arg>` | `<leader>cf` | Show where `<arg>` is defined. |
 | `Coq Search <args>` | `<leader>cs` | Show theorems about `<args>`. |
 | **Panel Management** | |
-| `CoqRestorePanels` | `<leader>cr` | Re-open the goal and info panels. |
-| `{n}CoqGotoGoal` | `<leader>cgg` | Scroll the goal panel to the start of the `n`th goal (defaults to 1). Number of lines shown is controlled by `g:coqtail_goal_lines`. |
-| `{n}CoqGotoGoal!` | `<leader>cGG` | Scroll the goal panel to the end of the `n`th goal. |
-| `CoqGotoGoalNext` | `g]` | Scroll the goal panel to the start of the next goal. |
-| `CoqGotoGoalNext!` | `G]` | Scroll the goal panel to the end of the next goal. |
-| `CoqGotoGoalPrev` | `g[` | Scroll the goal panel to the start of the previous goal. |
-| `CoqGotoGoalPrev!` | `G[` | Scroll the goal panel to the end of the previous goal. |
+| `CoqRestorePanels` | `<leader>cr` | Re-open the Goal and Info panels. |
+| `{n}CoqGotoGoal` | `<leader>cgg` | Scroll the Goal panel to the start of the `n`th goal (defaults to 1). Number of lines shown is controlled by `g:coqtail_goal_lines`. |
+| `{n}CoqGotoGoal!` | `<leader>cGG` | Scroll the Goal panel to the end of the `n`th goal. |
+| `CoqGotoGoalNext` | `g]` | Scroll the Goal panel to the start of the next goal. |
+| `CoqGotoGoalNext!` | `G]` | Scroll the Goal panel to the end of the next goal. |
+| `CoqGotoGoalPrev` | `g[` | Scroll the Goal panel to the start of the previous goal. |
+| `CoqGotoGoalPrev!` | `G[` | Scroll the Goal panel to the end of the previous goal. |
 
 ## Configuration
 
-The mappings shown above are set by default, but you can disable them all and
-define your own by setting `g:coqtail_nomap = 1` in your `.vimrc`.
-Alternatively, you can remap specific commands and the defaults will still be
-used for the rest.
+The mappings above are set by default, but you can disable them all and define
+your own by setting `g:coqtail_nomap = 1` in your `.vimrc`.
+Alternatively, you can keep the defaults but remap specific commands.
 For example, set `map <leader>ci <Plug>CoqInterrupt` in your `.vimrc` to not
 hijack `CTRL-C`.
 
-By default Coqtail will use the `coqtop` or `coqtop.opt` on your `PATH`.
+By default Coqtail will use the `coqtop/coqidetop` or `coqtop.opt` on your `PATH`.
 You can tell it to search instead in a specific directory by setting
 `b:coqtail_coq_path` before calling `CoqStart`.
 To set this option globally use `g:coqtail_coq_path`.
@@ -110,7 +110,9 @@ versions of Vincent Aravantinos'
 These scripts are used by default but can be disabled by setting
 `g:coqtail_nosyntax = 1` and `g:coqtail_noindent = 1` respectively.
 
-## Interoperability
+See `:help coqtail-configuration` for other configuration variables.
+
+## Vim Plugin Interoperability
 
 ### Jumping between matches
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -744,6 +744,7 @@ let s:cmd_opts = {
   \ 'CoqJumpToEnd': '',
   \ 'CoqGotoDef': '-bang -nargs=1',
   \ 'Coq': '-nargs=+ -complete=custom,s:queryComplete',
+  \ 'CoqRestorePanels': '',
   \ 'CoqGotoGoal': '-bang -count=1',
   \ 'CoqGotoGoalNext': '-bang',
   \ 'CoqGotoGoalPrev': '-bang',
@@ -768,6 +769,7 @@ function! s:commands() abort
   call s:cmdDef('CoqJumpToEnd', 'call coqtail#JumpToEnd()')
   call s:cmdDef('CoqGotoDef', 'call coqtail#GotoDef(<f-args>, <bang>0)')
   call s:cmdDef('Coq', 'call s:callCoqtail("query", "", {"args": [<f-args>]})')
+  call s:cmdDef('CoqRestorePanels', 'call s:openPanels(1, 1)')
   call s:cmdDef('CoqGotoGoal', 'call coqtail#GotoGoal(<count>, <bang>1)')
   call s:cmdDef('CoqGotoGoalNext', 'call coqtail#GotoGoal(-1, <bang>1)')
   call s:cmdDef('CoqGotoGoalPrev', 'call coqtail#GotoGoal(-2, <bang>1)')
@@ -794,6 +796,7 @@ function! s:mappings() abort
   nnoremap <buffer> <silent> <Plug>CoqAbout :Coq About <C-r>=<SID>getCurWord()<CR><CR>
   nnoremap <buffer> <silent> <Plug>CoqPrint :Coq Print <C-r>=<SID>getCurWord()<CR><CR>
   nnoremap <buffer> <silent> <Plug>CoqLocate :Coq Locate <C-r>=<SID>getCurWord()<CR><CR>
+  nnoremap <buffer> <silent> <Plug>CoqRestorePanels :CoqRestorePanels<CR>
   nnoremap <buffer> <silent> <Plug>CoqGotoGoalStart :<C-U>execute v:count1 'CoqGotoGoal'<CR>
   nnoremap <buffer> <silent> <Plug>CoqGotoGoalEnd :<C-U>execute v:count1 'CoqGotoGoal!'<CR>
   nnoremap <buffer> <silent> <Plug>CoqGotoGoalNextStart :CoqGotoGoalNext<CR>
@@ -821,6 +824,7 @@ function! s:mappings() abort
     \ ['About', 'a', 'n'],
     \ ['Print', 'p', 'n'],
     \ ['Locate', 'f', 'n'],
+    \ ['RestorePanels', 'r', 'ni'],
     \ ['GotoGoalStart', 'gg', 'ni'],
     \ ['GotoGoalEnd', 'GG', 'ni'],
     \ ['GotoGoalNextStart', '!g]', 'n'],

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -639,6 +639,13 @@ function! s:callCoqtail(cmd, cb, args) abort
     return [0, -1]
   endif
 
+  let l:opts = {
+    \ 'encoding': &encoding,
+    \ 'timeout': b:coqtail_timeout,
+    \ 'filename': expand('%:p')
+  \}
+
+  let a:args.opts = l:opts
   let l:args = [bufnr('%'), a:cmd, a:args]
   if a:cb !=# 'sync'
     " Async

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -642,6 +642,7 @@ function! s:callCoqtail(cmd, cb, args) abort
   let l:args = [bufnr('%'), a:cmd, a:args]
   if a:cb !=# 'sync'
     " Async
+    setlocal nomodifiable
     let l:opts = a:cb !=# '' ? {'callback': a:cb} : {'callback': 'coqtail#DefaultCB'}
     return [1, ch_sendexpr(b:coqtail_chan, l:args, l:opts)]
   else
@@ -740,6 +741,7 @@ endfunction
 
 " Print any error messages.
 function! coqtail#DefaultCB(chan, msg) abort
+  setlocal modifiable
   if a:msg.ret != v:null
     call s:err(a:msg.ret)
   endif

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -217,9 +217,6 @@ endfunction
 
 " Find the path corresponding to 'lib'. Used by includeexpr.
 function! coqtail#FindLib(lib) abort
-  if !s:coqtailRunning()
-    return a:lib
-  endif
   let [l:ok, l:lib] = s:callCoqtail('find_lib', 'sync', {'lib': a:lib})
   return (l:ok && l:lib != v:null) ? l:lib : a:lib
 endfunction

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -654,6 +654,14 @@ function! s:callCoqtail(cmd, cb, args) abort
   endif
 endfunction
 
+" Print any error messages.
+function! coqtail#DefaultCB(chan, msg) abort
+  setlocal modifiable
+  if a:msg.ret != v:null
+    call s:err(a:msg.ret)
+  endif
+endfunction
+
 " Initialize Python interface, commands, autocmds, and auxiliary panels.
 function! coqtail#Start(...) abort
   if s:port == -1
@@ -736,14 +744,6 @@ function! coqtail#JumpToEnd() abort
   let [l:ok, l:pos] = s:callCoqtail('endpoint', 'sync', {})
   if l:ok
     call cursor(l:pos)
-  endif
-endfunction
-
-" Print any error messages.
-function! coqtail#DefaultCB(chan, msg) abort
-  setlocal modifiable
-  if a:msg.ret != v:null
-    call s:err(a:msg.ret)
   endif
 endfunction
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -360,7 +360,7 @@ endfunction
 
 " Replace the contents of 'panel' with 'txt'.
 " TODO async: allow different restore behaviors
-function! s:replacePanel(panel, txt) abort
+function! s:replacePanel(panel, txt, scroll) abort
   if s:switchPanel(a:panel) == s:no_panel
     return
   endif
@@ -373,7 +373,7 @@ function! s:replacePanel(panel, txt) abort
   call append(0, a:txt)
 
   " Restore the view
-  if !g:coqtail_panel_scroll[a:panel]
+  if !a:scroll || !g:coqtail_panel_scroll[a:panel]
     call winrestview(l:view)
   endif
   call s:scrollPanel()
@@ -381,7 +381,7 @@ endfunction
 
 " Refresh the highlighting and auxiliary panels.
 " TODO async: main-panel only
-function! coqtail#Refresh(buf, highlights, panels) abort
+function! coqtail#Refresh(buf, highlights, panels, scroll) abort
   if a:buf != bufnr('%')
     return
   endif
@@ -398,7 +398,7 @@ function! coqtail#Refresh(buf, highlights, panels) abort
 
   " Update panels
   for [l:panel, l:txt] in items(a:panels)
-    call s:replacePanel(l:panel, l:txt)
+    call s:replacePanel(l:panel, l:txt, a:scroll)
   endfor
   call win_gotoid(l:win)
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -131,7 +131,7 @@ else
 
     " Handle requests
     while l:res[0] ==# 'call'
-      let l:repl = function(l:res[1], l:res[2])()
+      let l:repl = call(l:res[1], l:res[2])
       let l:res = s:send_wait(a:handle, l:repl, 1)
     endwhile
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -777,7 +777,7 @@ endfunction
 function! s:commands() abort
   call s:cmdDef('CoqStart', 'call coqtail#Start(<f-args>)')
   call s:cmdDef('CoqStop', 'call coqtail#Stop()')
-  call s:cmdDef('CoqInterrupt', 'call s:callCoqtail("interrupt", "", {})')
+  call s:cmdDef('CoqInterrupt', 'call s:callCoqtail("interrupt", "sync", {})')
   call s:cmdDef('CoqNext', 'call s:callCoqtail("step", "", {"steps": <count>})')
   call s:cmdDef('CoqUndo', 'call s:callCoqtail("rewind", "", {"steps": <count>})')
   call s:cmdDef('CoqToLine', 'call coqtail#ToLine(<count>)')

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -784,7 +784,10 @@ endfunction
 function! coqtail#Start(...) abort
   if s:port == -1
     let s:port = s:pyeval('CoqtailServer.start_server()')
-    autocmd VimLeavePre * call s:pyeval('CoqtailServer.stop_server()') | let s:port = -1
+    augroup coqtail#StopServer
+      autocmd! *
+      autocmd VimLeavePre * call s:pyeval('CoqtailServer.stop_server()') | let s:port = -1
+    augroup end
   endif
 
   if s:coqtailRunning()

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -784,7 +784,7 @@ function! coqtail#Start(...) abort
     augroup coqtail#StopServer
       autocmd! *
       autocmd VimLeavePre * call s:pyeval('CoqtailServer.stop_server()') | let s:port = -1
-    augroup end
+    augroup END
   endif
 
   if s:coqtailRunning()
@@ -835,7 +835,7 @@ function! coqtail#Start(...) abort
       autocmd BufWinLeave <buffer> call s:hidePanels()
       autocmd BufWinEnter <buffer> call s:openPanels(0, 1)
       autocmd QuitPre <buffer> call coqtail#Stop()
-    augroup end
+    augroup END
   endif
 
   return 1

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -737,6 +737,7 @@ endfunction
 let s:cmd_opts = {
   \ 'CoqStart': '-nargs=* -complete=file',
   \ 'CoqStop': '',
+  \ 'CoqInterrupt': '',
   \ 'CoqNext': '-count=1',
   \ 'CoqUndo': '-count=1',
   \ 'CoqToLine': '-count=0',
@@ -752,7 +753,7 @@ let s:cmd_opts = {
 \}
 function! s:cmdDef(name, act) abort
   " Start Coqtail first if needed
-  let l:act = a:name !=# 'CoqStart' && a:name !=# 'CoqStop'
+  let l:act = a:name !~# '\(Start\|Stop\|Interrupt\)$'
     \ ? printf('if s:coqtailRunning() || coqtail#Start() | %s | endif', a:act)
     \ : a:act
   execute printf('command! -buffer -bar %s %s %s', s:cmd_opts[a:name], a:name, l:act)
@@ -762,6 +763,7 @@ endfunction
 function! s:commands() abort
   call s:cmdDef('CoqStart', 'call coqtail#Start(<f-args>)')
   call s:cmdDef('CoqStop', 'call coqtail#Stop()')
+  call s:cmdDef('CoqInterrupt', 'call s:callCoqtail("interrupt", "", {})')
   call s:cmdDef('CoqNext', 'call s:callCoqtail("step", "", {"steps": <count>})')
   call s:cmdDef('CoqUndo', 'call s:callCoqtail("rewind", "", {"steps": <count>})')
   call s:cmdDef('CoqToLine', 'call coqtail#ToLine(<count>)')
@@ -780,6 +782,7 @@ endfunction
 function! s:mappings() abort
   nnoremap <buffer> <silent> <Plug>CoqStart :CoqStart<CR>
   nnoremap <buffer> <silent> <Plug>CoqStop :CoqStop<CR>
+  nnoremap <buffer> <silent> <Plug>CoqInterrupt :CoqInterrupt<CR>
   nnoremap <buffer> <silent> <Plug>CoqNext :<C-U>execute v:count1 'CoqNext'<CR>
   nnoremap <buffer> <silent> <Plug>CoqUndo :<C-U>execute v:count1 'CoqUndo'<CR>
   nnoremap <buffer> <silent> <Plug>CoqToLine :<C-U>execute v:count 'CoqToLine'<CR>
@@ -813,6 +816,7 @@ function! s:mappings() abort
   let l:maps = [
     \ ['Start', 'c', 'n'],
     \ ['Stop', 'q', 'n'],
+    \ ['Interrupt', '!<C-c>', 'n'],
     \ ['Next', 'j', 'ni'],
     \ ['Undo', 'k', 'ni'],
     \ ['ToLine', 'l', 'ni'],

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -11,12 +11,12 @@ let g:coqtail_sourced = 1
 if has('python3')
   command! -nargs=1 Py py3 <args>
   function! s:pyeval(expr) abort
-    return function('py3eval', [a:expr])
+    return py3eval(a:expr)
   endfunction
 elseif has('python')
   command! -nargs=1 Py py <args>
   function! s:pyeval(expr) abort
-    return function('pyeval', [a:expr])
+    return pyeval(a:expr)
   endfunction
 else
   echoerr 'Coqtail requires Python support.'
@@ -437,7 +437,7 @@ function! coqtail#ParseCoqProj(file, silent) abort
   let l:dir_opts = {'-R': 2, '-Q': 2, '-I': 1, '-include': 1}
 
   let l:txt = join(readfile(a:file))
-  let l:raw_args = s:pyeval(printf('shlex.split(r%s)', string(l:txt)))()
+  let l:raw_args = s:pyeval(printf('shlex.split(r%s)', string(l:txt)))
 
   let l:proj_args = []
   let l:idx = 0
@@ -677,7 +677,7 @@ endfunction
 " Initialize Python interface, commands, autocmds, and goals and info panels.
 function! coqtail#Start(...) abort
   if s:port == -1
-    let s:port = s:pyeval('start_server()')()
+    let s:port = s:pyeval('start_server()')
   endif
 
   if s:coqtailRunning()

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -51,8 +51,8 @@ if s:has_channel
     return ch_sendexpr(a:handle, a:expr, a:options)
   endfunction
 
-  function! s:ch_evalexpr(handle, expr) abort
-    return ch_evalexpr(a:handle, a:expr)
+  function! s:ch_evalexpr(handle, expr, options) abort
+    return ch_evalexpr(a:handle, a:expr, a:options)
   endfunction
 else
   " Rate in ms to check if Coqtail is done computing.
@@ -123,7 +123,7 @@ else
   endfunction
 
   " Send a command to execute and reply to any requests from Coqtail.
-  function! s:ch_evalexpr(handle, expr) abort
+  function! s:ch_evalexpr(handle, expr, options) abort
     " Remember CTRL-C mapping and disable
     let s:int_map = maparg('<C-c>', 'n')
     call s:disable_int()
@@ -763,7 +763,9 @@ function! s:callCoqtail(cmd, cb, args) abort
     return [1, s:ch_sendexpr(b:coqtail_chan, l:args, l:opts)]
   else
     " Sync
-    let l:res = s:ch_evalexpr(b:coqtail_chan, l:args)
+    " Don't wait for interrupt to return
+    let l:opts = a:cmd ==# 'interrupt' ? {'timeout': 0} : {}
+    let l:res = s:ch_evalexpr(b:coqtail_chan, l:args, l:opts)
     return type(l:res) == s:t_dict
       \ ? [l:res.buf == bufnr('%'), l:res.ret]
       \ : [0, -1]

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -348,7 +348,8 @@ function! coqtail#start(...) abort
     call s:call('splash', 'sync', {
       \ 'version': b:coqtail_version,
       \ 'width': winwidth(l:info_win),
-      \ 'height': winheight(l:info_win)})
+      \ 'height': winheight(l:info_win),
+      \ 'deprecated': has('python')})
     call s:call('refresh', '', {})
 
     " Autocmds to do some detection when editing an already checked

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -322,7 +322,7 @@ function! coqtail#start(...) abort
     let b:cmds_pending = 0
 
     " Open channel with Coqtail server
-    let b:coqtail_chan = coqtail#channel#new(g:coqtail#compat#has_channel)
+    let b:coqtail_chan = coqtail#channel#new()
     call b:coqtail_chan.open('localhost:' . s:port, s:chanopts)
 
     " Check for a Coq project file

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -288,9 +288,10 @@ endfunction
 
 " Print any error messages.
 function! coqtail#defaultCB(chan, msg) abort
-  let b:cmds_pending -= 1
-  if b:cmds_pending == 0
-    setlocal modifiable
+  let l:pending = getbufvar(a:msg.buf, 'cmds_pending')
+  call setbufvar(a:msg.buf, 'cmds_pending', l:pending - 1)
+  if l:pending - 1 == 0
+    call setbufvar(a:msg.buf, '&modifiable', 1)
   endif
   if a:msg.ret != v:null
     call coqtail#util#err(a:msg.ret)

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -116,7 +116,7 @@ endfunction
 " Get a list of possible locations of the definition of 'target'.
 function! s:finddef(target) abort
   let [l:ok, l:loc] = s:call('find_def', 'sync', {'target': a:target})
-  return (!l:ok || type(l:loc) != g:coqtail#comapt#t_list) ? v:null : l:loc
+  return (!l:ok || type(l:loc) != g:coqtail#compat#t_list) ? v:null : l:loc
 endfunction
 
 " Populate the quickfix list with possible locations of the definition of
@@ -146,7 +146,7 @@ function! coqtail#gotodef(target, bang) abort
 
   if l:found_match
     " Filter duplicate matches
-    call coqtail#util#dedup_qfList()
+    call coqtail#util#dedup_qflist()
 
     " Jump to first if possible, otherwise open list
     try
@@ -453,12 +453,12 @@ function! s:mappings() abort
   inoremap <buffer> <silent> <Plug>CoqToLine <C-\><C-o>:CoqToLine<CR>
   inoremap <buffer> <silent> <Plug>CoqToTop <C-\><C-o>:CoqToTop<CR>
   inoremap <buffer> <silent> <Plug>CoqJumpToEnd <C-\><C-o>:CoqJumpToEnd<CR>
-  nnoremap <buffer> <silent> <Plug>CoqGotoDef :CoqGotoDef <C-r>=<SID>getCurWord()<CR><CR>
-  nnoremap <buffer> <silent> <Plug>CoqSearch :Coq Search <C-r>=<SID>getCurWord()<CR><CR>
-  nnoremap <buffer> <silent> <Plug>CoqCheck :Coq Check <C-r>=<SID>getCurWord()<CR><CR>
-  nnoremap <buffer> <silent> <Plug>CoqAbout :Coq About <C-r>=<SID>getCurWord()<CR><CR>
-  nnoremap <buffer> <silent> <Plug>CoqPrint :Coq Print <C-r>=<SID>getCurWord()<CR><CR>
-  nnoremap <buffer> <silent> <Plug>CoqLocate :Coq Locate <C-r>=<SID>getCurWord()<CR><CR>
+  nnoremap <buffer> <silent> <Plug>CoqGotoDef :CoqGotoDef <C-r>=coqtail#util#getcurword()<CR><CR>
+  nnoremap <buffer> <silent> <Plug>CoqSearch :Coq Search <C-r>=coqtail#util#getcurword()<CR><CR>
+  nnoremap <buffer> <silent> <Plug>CoqCheck :Coq Check <C-r>=coqtail#util#getcurword()<CR><CR>
+  nnoremap <buffer> <silent> <Plug>CoqAbout :Coq About <C-r>=coqtail#util#getcurword()<CR><CR>
+  nnoremap <buffer> <silent> <Plug>CoqPrint :Coq Print <C-r>=coqtail#util#getcurword()<CR><CR>
+  nnoremap <buffer> <silent> <Plug>CoqLocate :Coq Locate <C-r>=coqtail#util#getcurword()<CR><CR>
   nnoremap <buffer> <silent> <Plug>CoqRestorePanels :CoqRestorePanels<CR>
   nnoremap <buffer> <silent> <Plug>CoqGotoGoalStart :<C-U>execute v:count1 'CoqGotoGoal'<CR>
   nnoremap <buffer> <silent> <Plug>CoqGotoGoalEnd :<C-U>execute v:count1 'CoqGotoGoal!'<CR>

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -8,7 +8,10 @@ endif
 let g:loaded_coqtail = 1
 
 let s:python_dir = expand('<sfile>:p:h:h') . '/python'
-call coqtail#compat#init(s:python_dir)
+if !coqtail#compat#init(s:python_dir)
+  echoerr 'Coqtail requires Python support.'
+  finish
+endif
 
 Py from coqtail import ChannelManager, Coqtail, CoqtailServer
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -942,7 +942,7 @@ function! s:mappings() abort
   nnoremap <buffer> <silent> <Plug>CoqToggleDebug :CoqToggleDebug<CR>
 
   " Use default mappings unless user opted out
-  if exists('g:coqtail_nomap') && g:coqtail_nomap
+  if get(g:, 'coqtail_nomap', 0)
     return
   endif
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -2,138 +2,15 @@
 " Coqtail Python interface and window management.
 
 " Only source once.
-if exists('g:coqtail_sourced')
+if exists('g:loaded_coqtail')
   finish
 endif
-let g:coqtail_sourced = 1
+let g:loaded_coqtail = 1
 
-" Check Python version.
-if has('python3')
-  command! -nargs=1 Py py3 <args>
-  function! s:pyeval(expr) abort
-    return py3eval(a:expr)
-  endfunction
-elseif has('python')
-  command! -nargs=1 Py py <args>
-  function! s:pyeval(expr) abort
-    return pyeval(a:expr)
-  endfunction
-else
-  echoerr 'Coqtail requires Python support.'
-  finish
-endif
-
-" Add python directory to path so Python functions can be called.
 let s:python_dir = expand('<sfile>:p:h:h') . '/python'
-Py import shlex, sys, vim
-Py if not vim.eval('s:python_dir') in sys.path:
-  \    sys.path.insert(0, vim.eval('s:python_dir'))
+call coqtail#compat#init(s:python_dir)
+
 Py from coqtail import ChannelManager, Coqtail, CoqtailServer
-
-" Vim compatibility.
-let s:t_dict = type({})
-let s:t_list = type([])
-let s:has_channel = has('channel') && has('patch-8.0.0001')
-if s:has_channel
-  function! s:ch_open(address, options) abort
-    return ch_open(a:address, a:options)
-  endfunction
-
-  function! s:ch_close(handle) abort
-    return ch_close(a:handle)
-  endfunction
-
-  function! s:ch_status(handle) abort
-    return ch_status(a:handle)
-  endfunction
-
-  function! s:ch_sendexpr(handle, expr, options) abort
-    return ch_sendexpr(a:handle, a:expr, a:options)
-  endfunction
-
-  function! s:ch_evalexpr(handle, expr, options) abort
-    return ch_evalexpr(a:handle, a:expr, a:options)
-  endfunction
-else
-  " Rate in ms to check if Coqtail is done computing.
-  let s:poll_rate = 10
-
-  " Unique session ID
-  let s:session = 0
-
-  function! s:ch_open(address, options) abort
-    return s:pyeval(printf('ChannelManager.open("%s")', a:address))
-  endfunction
-
-  function! s:ch_close(handle) abort
-    return s:pyeval(printf('ChannelManager.close(%d)', a:handle))
-  endfunction
-
-  function! s:ch_status(handle) abort
-    return s:pyeval(printf('ChannelManager.status(%d)', a:handle))
-  endfunction
-
-  function! s:ch_sendexpr(handle, expr, options) abort
-    echoerr 'Calling ch_sendexpr in synchronous mode.'
-  endfunction
-
-  " Send a command to Coqtail and wait for the response.
-  function! s:send_wait(handle, session, expr, reply) abort
-    let l:returns = a:expr[1] !=# 'interrupt'
-    call s:pyeval(printf(
-      \ 'ChannelManager.send(%d, %s, %s, reply=%s, returns=bool(%s))',
-      \ a:handle,
-      \ a:expr[1] !=# 'interrupt' ? a:session : 'None',
-      \ json_encode(a:expr),
-      \ a:reply != 0 ? a:reply : 'None',
-      \ l:returns
-    \))
-
-    " Continually check if Coqtail is done computing
-    while l:returns
-      let l:res = json_decode(s:pyeval(printf('ChannelManager.poll(%d)', a:handle)))
-      if type(l:res) == s:t_list
-        return l:res
-      endif
-
-      execute printf('sleep %dm', s:poll_rate)
-    endwhile
-
-    return v:null
-  endfunction
-
-  " Send a command to execute and reply to any requests from Coqtail.
-  function! s:ch_evalexpr(handle, expr, options) abort
-    let s:session += 1
-    let l:session = s:session
-    let l:res = v:null
-    let l:did_int = 0
-
-    " Retry until Coqtop responds
-    while 1
-      try
-        let l:res = s:send_wait(a:handle, l:session, a:expr, 0)
-
-        " Handle requests
-        while type(l:res) == s:t_list && l:res[0] ==# 'call'
-          let l:val = call(l:res[1], l:res[2])
-          let l:res = s:send_wait(a:handle, l:session, l:val, l:res[-1])
-        endwhile
-      catch /^Vim:Interrupt$/
-        " Interrupt Coqtop and retry
-        if l:did_int
-          call s:err("Coqtail is stuck. Try restarting to fix.")
-          return v:null
-        endif
-        let l:did_int = 1
-        call s:send_wait(a:handle, l:session, [a:expr[0], 'interrupt', {}], 0)
-        continue
-      endtry
-
-      return type(l:res) == s:t_list ? l:res[1] : v:null
-    endwhile
-  endfunction
-endif
 
 " Initialize global variables.
 " Supported Coq versions (-1 means any number).
@@ -199,16 +76,6 @@ if !exists('g:coqtail_panel_scroll')
     \ s:info_panel: 1
   \}
 endif
-
-" Print a message with warning highlighting.
-function! s:warn(msg) abort
-  echohl WarningMsg | echom a:msg | echohl None
-endfunction
-
-" Print a message with error highlighting.
-function! s:err(msg) abort
-  echohl ErrorMsg | echom a:msg | echohl None
-endfunction
 
 " Find the path corresponding to 'lib'. Used by includeexpr.
 function! coqtail#FindLib(lib) abort
@@ -492,27 +359,10 @@ function! coqtail#GotoGoal(ngoal, start) abort
   return 1
 endfunction
 
-" Remove entries in the quickfix list with the same position.
-function! s:uniqQFList() abort
-  let l:qfl = getqflist()
-  let l:seen = {}
-  let l:uniq = []
-
-  for l:entry in l:qfl
-    let l:pos = string([l:entry.lnum, l:entry.col])
-    if !has_key(l:seen, l:pos)
-      let l:seen[l:pos] = 1
-      let l:uniq = add(l:uniq, l:entry)
-    endif
-  endfor
-
-  call setqflist(l:uniq)
-endfunction
-
 " Get a list of possible locations of the definition of 'target'.
 function! s:findDef(target) abort
   let [l:ok, l:loc] = s:callCoqtail('find_def', 'sync', {'target': a:target})
-  return (!l:ok || type(l:loc) != s:t_list) ? v:null : l:loc
+  return (!l:ok || type(l:loc) != g:coqtail#comapt#t_list) ? v:null : l:loc
 endfunction
 
 " Populate the quickfix list with possible locations of the definition of
@@ -520,8 +370,8 @@ endfunction
 function! coqtail#GotoDef(target, bang) abort
   let l:bang = a:bang ? '!' : ''
   let l:loc = s:findDef(a:target)
-  if type(l:loc) != s:t_list
-    call s:warn('Cannot locate ' . a:target . '.')
+  if type(l:loc) != g:coqtail#compat#t_list
+    call coqtail#util#warn('Cannot locate ' . a:target . '.')
     return
   endif
   let [l:path, l:searches] = l:loc
@@ -542,7 +392,7 @@ function! coqtail#GotoDef(target, bang) abort
 
   if l:found_match
     " Filter duplicate matches
-    call s:uniqQFList()
+    call coqtail#util#dedup_qfList()
 
     " Jump to first if possible, otherwise open list
     try
@@ -556,7 +406,7 @@ endfunction
 " Create a list of tags for 'target'.
 function! coqtail#GetTags(target, flags, info) abort
   let l:loc = s:findDef(a:target)
-  if type(l:loc) != s:t_list
+  if type(l:loc) != g:coqtail#compat#t_list
     return v:null
   endif
   let [l:path, l:searches] = l:loc
@@ -568,83 +418,6 @@ function! coqtail#GetTags(target, flags, info) abort
   endfor
 
   return l:tags
-endfunction
-
-" Read a CoqProject file and parse it into options that can be passed to
-" Coqtop.
-function! coqtail#ParseCoqProj(file, silent) abort
-  let l:file_dir = fnamemodify(a:file, ':p:h')
-  let l:dir_opts = {'-R': 2, '-Q': 2, '-I': 1, '-include': 1}
-
-  let l:txt = join(readfile(a:file))
-  let l:raw_args = s:pyeval(printf('shlex.split(r%s)', string(l:txt)))
-
-  let l:proj_args = []
-  let l:idx = 0
-  while l:idx < len(l:raw_args)
-    " Make paths absolute for -R, -Q, etc
-    if has_key(l:dir_opts, l:raw_args[l:idx])
-      let l:absdir = l:raw_args[l:idx + 1]
-      if l:absdir[0] !=# '/'
-        " Join relative paths with 'l:file_dir'
-        let l:absdir = join([l:file_dir, l:absdir], '/')
-      endif
-      let l:raw_args[l:idx + 1] = fnamemodify(l:absdir, ':p')
-
-      " Can be '-R dir -as coqdir' in 8.4
-      let l:end = l:idx + l:dir_opts[l:raw_args[l:idx]]
-      if l:raw_args[l:end] ==# '-as' || get(l:raw_args, l:end + 1, '') ==# '-as'
-        let l:end = l:idx + 3
-      endif
-      let l:proj_args += l:raw_args[l:idx : l:end]
-      let l:idx = l:end
-    endif
-
-    " Pass through options following -arg
-    if l:raw_args[l:idx] ==# '-arg'
-      let l:proj_args = add(l:proj_args, l:raw_args[l:idx + 1])
-      let l:idx += 1
-    endif
-
-    let l:idx += 1
-  endwhile
-
-  return l:proj_args
-endfunction
-
-" Search for a CoqProject file using 'g:coqtail_project_name' starting in the
-" current directory and recursively try parent directories until '/' is
-" reached. Return the file name and a list of arguments to pass to Coqtop.
-function! coqtail#FindCoqProj() abort
-  let l:proj_args = []
-  let l:proj_file = findfile(g:coqtail_project_name, '.;')
-  if l:proj_file !=# ''
-    let l:proj_args = coqtail#ParseCoqProj(l:proj_file, 0)
-  endif
-
-  return [l:proj_file, l:proj_args]
-endfunction
-
-" Get the word under the cursor using the special '<cword>' variable. First
-" add some characters to the 'iskeyword' option to treat them as part of the
-" current word.
-function! s:getCurWord() abort
-  " Add '.' to definition of a keyword
-  let l:old_keywd = &iskeyword
-  setlocal iskeyword+=.
-
-  let l:cword = expand('<cword>')
-
-  " Strip trailing '.'s
-  let l:dotidx = match(l:cword, '[.]\+$')
-  if l:dotidx > -1
-    let l:cword = l:cword[: l:dotidx - 1]
-  endif
-
-  " Reset iskeyword
-  let &l:iskeyword = l:old_keywd
-
-  return l:cword
 endfunction
 
 " List query options for use in Coq command completion.
@@ -681,7 +454,7 @@ function! s:cleanup() abort
   call s:clearHighlighting()
 
   " Close the channel
-  silent! call s:ch_close(b:coqtail_chan)
+  silent! call b:coqtail_chan.close()
   let b:coqtail_chan = 0
 endfunction
 
@@ -729,9 +502,11 @@ endfunction
 " TODO async: main-panel only
 function! s:coqtailRunning() abort
   try
-    return s:ch_status(b:coqtail_chan) ==# 'open'
+    let l:ok = b:coqtail_chan.status() ==# 'open'
   catch
-    return 0
+    let l:ok = 0
+  finally
+    return l:ok
   endtry
 endfunction
 
@@ -749,18 +524,18 @@ function! s:callCoqtail(cmd, cb, args) abort
   \}
   let l:args = [bufnr('%'), a:cmd, a:args]
 
-  if a:cb !=# 'sync' && s:has_channel
+  if a:cb !=# 'sync' && g:coqtail#compat#has_channel
     " Async
     let b:cmds_pending += 1
     setlocal nomodifiable
     let l:opts = a:cb !=# '' ? {'callback': a:cb} : {'callback': 'coqtail#DefaultCB'}
-    return [1, s:ch_sendexpr(b:coqtail_chan, l:args, l:opts)]
+    return [1, b:coqtail_chan.sendexpr(l:args, l:opts)]
   else
     " Sync
     " Don't wait for interrupt to return
     let l:opts = a:cmd ==# 'interrupt' ? {'timeout': 0} : {}
-    let l:res = s:ch_evalexpr(b:coqtail_chan, l:args, l:opts)
-    return type(l:res) == s:t_dict
+    let l:res = b:coqtail_chan.evalexpr(l:args, l:opts)
+    return type(l:res) == g:coqtail#compat#t_dict
       \ ? [l:res.buf == bufnr('%'), l:res.ret]
       \ : [0, -1]
   endif
@@ -773,35 +548,37 @@ function! coqtail#DefaultCB(chan, msg) abort
     setlocal modifiable
   endif
   if a:msg.ret != v:null
-    call s:err(a:msg.ret)
+    call coqtail#util#err(a:msg.ret)
   endif
 endfunction
 
 " Initialize Python interface, commands, autocmds, and auxiliary panels.
 function! coqtail#Start(...) abort
   if s:port == -1
-    let s:port = s:pyeval('CoqtailServer.start_server()')
+    let s:port = coqtail#compat#pyeval('CoqtailServer.start_server()')
     augroup coqtail#StopServer
       autocmd! *
-      autocmd VimLeavePre * call s:pyeval('CoqtailServer.stop_server()') | let s:port = -1
+      autocmd VimLeavePre *
+        \ call coqtail#compat#pyeval('CoqtailServer.stop_server()') | let s:port = -1
     augroup END
   endif
 
   if s:coqtailRunning()
-    call s:warn('Coq is already running.')
+    call coqtail#util#warn('Coq is already running.')
   else
     " Check if version supported
     let [b:coqtail_version, l:supported] = s:checkVersion()
     if !l:supported
-      call s:warn(printf(s:unsupported_msg, b:coqtail_version))
+      call coqtail#util#warn(printf(s:unsupported_msg, b:coqtail_version))
     endif
     let b:cmds_pending = 0
 
     " Open channel with Coqtail server
-    let b:coqtail_chan = s:ch_open('localhost:' . s:port, s:chanopts)
+    let b:coqtail_chan = coqtail#channel#new(g:coqtail#compat#has_channel)
+    call b:coqtail_chan.open('localhost:' . s:port, s:chanopts)
 
     " Check for a Coq project file
-    let [b:coqtail_project_file, l:proj_args] = coqtail#FindCoqProj()
+    let [b:coqtail_project_file, l:proj_args] = coqtail#coqproject#locate()
 
     " Prepare auxiliary panels
     call s:initPanels()
@@ -814,7 +591,7 @@ function! coqtail#Start(...) abort
       \ 'args': map(copy(l:proj_args + a:000), 'expand(v:val)')})
     if !l:ok || l:msg != v:null
       let l:msg = l:ok && l:msg != v:null ? l:msg : 'Failed to launch Coq.'
-      call s:err(l:msg)
+      call coqtail#util#err(l:msg)
       call coqtail#Stop()
       return 0
     endif

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -301,7 +301,8 @@ endfunction
 " Initialize Python interface, commands, autocmds, and auxiliary panels.
 function! coqtail#start(...) abort
   if s:port == -1
-    let s:port = coqtail#compat#pyeval('CoqtailServer.start_server()')
+    let s:port = coqtail#compat#pyeval(printf(
+      \ 'CoqtailServer.start_server(bool(%d))', !g:coqtail#compat#has_channel))
     augroup coqtail#StopServer
       autocmd! *
       autocmd VimLeavePre *

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -348,7 +348,7 @@ function! coqtail#start(...) abort
       \ 'version': b:coqtail_version,
       \ 'width': winwidth(l:info_win),
       \ 'height': winheight(l:info_win)})
-    call s:call('refresh', 'sync', {})
+    call s:call('refresh', '', {})
 
     " Autocmds to do some detection when editing an already checked
     " portion of the code, and to hide and restore the info and goal
@@ -358,7 +358,7 @@ function! coqtail#start(...) abort
       autocmd InsertEnter <buffer> call s:call('sync', 'sync', {})
       autocmd BufWinLeave <buffer> call coqtail#panels#hide()
       autocmd BufWinEnter <buffer>
-        \ call coqtail#panels#open(0) | call s:call('refresh', 'sync', {})
+        \ call coqtail#panels#open(0) | call s:call('refresh', '', {})
       autocmd QuitPre <buffer> call coqtail#stop()
     augroup END
   endif
@@ -429,7 +429,7 @@ function! s:commands() abort
   call s:cmddef('CoqGotoDef', 'call coqtail#gotodef(<f-args>, <bang>0)')
   call s:cmddef('Coq', 'call s:call("query", "", {"args": [<f-args>]})')
   call s:cmddef('CoqRestorePanels',
-    \ 'call coqtail#panels#open(1) | call s:call("refresh", "sync", {})')
+    \ 'call coqtail#panels#open(1) | call s:call("refresh", "", {})')
   call s:cmddef('CoqGotoGoal', 'call coqtail#gotogoal(<count>, <bang>1)')
   call s:cmddef('CoqGotoGoalNext', 'call coqtail#gotogoal(-1, <bang>1)')
   call s:cmddef('CoqGotoGoalPrev', 'call coqtail#gotogoal(-2, <bang>1)')

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -378,7 +378,6 @@ endfunction
 function! coqtail#toline(line) abort
   " If no line was given then use the cursor's position,
   " otherwise use the last column in the line
-  " TODO async: fix on multi-byte characters
   call s:call('to_line', '', {
     \ 'line': (a:line == 0 ? line('.') : a:line) - 1,
     \ 'col': (a:line == 0 ? col('.') : len(getline(a:line))) - 1})

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -193,7 +193,6 @@ function! s:querycomplete(arg, cmd, cursor) abort
 endfunction
 
 " Clean up commands, panels, and autocommands.
-" TODO async: main-panel only
 function! s:cleanup() abort
   " Clean up auxiliary panels
   call coqtail#panels#cleanup()
@@ -247,7 +246,6 @@ function! s:coqversion() abort
 endfunction
 
 " Check if the channel with Coqtail is open.
-" TODO async: main-panel only
 function! s:running() abort
   try
     let l:ok = b:coqtail_chan.status() ==# 'open'
@@ -259,7 +257,6 @@ function! s:running() abort
 endfunction
 
 " Send a request to Coqtail.
-" TODO async: main-panel only
 function! s:call(cmd, cb, args) abort
   if !s:running()
     return [0, -1]

--- a/autoload/coqtail/channel.vim
+++ b/autoload/coqtail/channel.vim
@@ -1,117 +1,116 @@
 " Author: Wolf Honore
 " Python communication channels.
 
-function! coqtail#channel#new(has_channel) abort
-  let l:chan = {'has_channel': a:has_channel, 'handle': -1}
-  let l:f_prefix = a:has_channel ? 'chan' : 'nochan'
+function! coqtail#channel#new() abort
+  let l:chan = {'handle': -1}
   for l:f in ['open', 'close', 'status', 'sendexpr', 'evalexpr']
-    let l:chan[l:f] = function(printf('s:%s_%s', l:f_prefix, l:f))
+    let l:chan[l:f] = function('s:' . l:f)
   endfor
   return l:chan
 endfunction
 
-" With +channel.
-function! s:chan_open(address, options) dict abort
-  let self.handle = ch_open(a:address, a:options)
-  return self.handle
-endfunction
+if g:coqtail#compat#has_channel
+  function! s:open(address, options) dict abort
+    let self.handle = ch_open(a:address, a:options)
+    return self.handle
+  endfunction
 
-function! s:chan_close() dict abort
-  return ch_close(self.handle)
-endfunction
+  function! s:close() dict abort
+    return ch_close(self.handle)
+  endfunction
 
-function! s:chan_status() dict abort
-  return ch_status(self.handle)
-endfunction
+  function! s:status() dict abort
+    return ch_status(self.handle)
+  endfunction
 
-function! s:chan_sendexpr(expr, options) dict abort
-  return ch_sendexpr(self.handle, a:expr, a:options)
-endfunction
+  function! s:sendexpr(expr, options) dict abort
+    return ch_sendexpr(self.handle, a:expr, a:options)
+  endfunction
 
-function! s:chan_evalexpr(expr, options) dict abort
-  return ch_evalexpr(self.handle, a:expr, a:options)
-endfunction
+  function! s:evalexpr(expr, options) dict abort
+    return ch_evalexpr(self.handle, a:expr, a:options)
+  endfunction
+else
+  " Rate in ms to check if Coqtail is done computing.
+  let s:poll_rate = 10
 
-" With -channel.
-" Rate in ms to check if Coqtail is done computing.
-let s:poll_rate = 10
+  " Unique session ID.
+  let s:session = 0
 
-" Unique session ID.
-let s:session = 0
+  function! s:open(address, options) dict abort
+    let self.handle = coqtail#compat#pyeval(printf(
+      \ 'ChannelManager.open("%s")', a:address
+    \))
+    return self.handle
+  endfunction
 
-function! s:nochan_open(address, options) dict abort
-  let self.handle = coqtail#compat#pyeval(printf(
-    \ 'ChannelManager.open("%s")', a:address
-  \))
-  return self.handle
-endfunction
+  function! s:close() dict abort
+    return coqtail#compat#pyeval(printf('ChannelManager.close(%d)', self.handle))
+  endfunction
 
-function! s:nochan_close() dict abort
-  return coqtail#compat#pyeval(printf('ChannelManager.close(%d)', self.handle))
-endfunction
+  function! s:status() dict abort
+    return coqtail#compat#pyeval(printf('ChannelManager.status(%d)', self.handle))
+  endfunction
 
-function! s:nochan_status() dict abort
-  return coqtail#compat#pyeval(printf('ChannelManager.status(%d)', self.handle))
-endfunction
+  function! s:sendexpr(expr, options) dict abort
+    echoerr 'Calling ch_sendexpr in synchronous mode.'
+  endfunction
 
-function! s:nochan_sendexpr(expr, options) dict abort
-  echoerr 'Calling ch_sendexpr in synchronous mode.'
-endfunction
+  " Send a command to Coqtail and wait for the response.
+  function! s:send_wait(handle, session, expr, reply) abort
+    let l:returns = a:expr[1] !=# 'interrupt'
+    call coqtail#compat#pyeval(printf(
+      \ 'ChannelManager.send(%d, %s, %s, reply=%s, returns=bool(%s))',
+      \ a:handle,
+      \ a:expr[1] !=# 'interrupt' ? a:session : 'None',
+      \ json_encode(a:expr),
+      \ a:reply != 0 ? a:reply : 'None',
+      \ l:returns
+    \))
 
-" Send a command to Coqtail and wait for the response.
-function! s:send_wait(handle, session, expr, reply) abort
-  let l:returns = a:expr[1] !=# 'interrupt'
-  call coqtail#compat#pyeval(printf(
-    \ 'ChannelManager.send(%d, %s, %s, reply=%s, returns=bool(%s))',
-    \ a:handle,
-    \ a:expr[1] !=# 'interrupt' ? a:session : 'None',
-    \ json_encode(a:expr),
-    \ a:reply != 0 ? a:reply : 'None',
-    \ l:returns
-  \))
-
-  " Continually check if Coqtail is done computing
-  let l:poll = printf('ChannelManager.poll(%d)', a:handle)
-  while l:returns
-    let l:res = json_decode(coqtail#compat#pyeval(l:poll))
-    if type(l:res) == g:coqtail#compat#t_list
-      return l:res
-    endif
-
-    execute printf('sleep %dm', s:poll_rate)
-  endwhile
-
-  return v:null
-endfunction
-
-" Send a command to execute and reply to any requests from Coqtail.
-function! s:nochan_evalexpr(expr, options) dict abort
-  let s:session += 1
-  let l:session = s:session
-  let l:res = v:null
-  let l:did_int = 0
-
-  " Retry until Coqtop responds
-  while 1
-    try
-      let l:res = s:send_wait(self.handle, l:session, a:expr, 0)
-
-      " Handle requests
-      while type(l:res) == g:coqtail#compat#t_list && l:res[0] ==# 'call'
-        let l:val = call(l:res[1], l:res[2])
-        let l:res = s:send_wait(self.handle, l:session, l:val, l:res[-1])
-      endwhile
-    catch /^Vim:Interrupt$/
-      " Interrupt Coqtop and retry
-      if l:did_int
-        call coqtail#util#err('Coqtail is stuck. Try restarting to fix.')
-        return v:null
+    " Continually check if Coqtail is done computing
+    let l:poll = printf('ChannelManager.poll(%d)', a:handle)
+    while l:returns
+      let l:res = json_decode(coqtail#compat#pyeval(l:poll))
+      if type(l:res) == g:coqtail#compat#t_list
+        return l:res
       endif
-      let l:did_int = 1
-      call s:send_wait(self.handle, l:session, [a:expr[0], 'interrupt', {}], 0)
-      continue
-    endtry
 
-    return type(l:res) == g:coqtail#compat#t_list ? l:res[1] : v:null
-  endwhile
-endfunction
+      execute printf('sleep %dm', s:poll_rate)
+    endwhile
+
+    return v:null
+  endfunction
+
+  " Send a command to execute and reply to any requests from Coqtail.
+  function! s:evalexpr(expr, options) dict abort
+    let s:session += 1
+    let l:session = s:session
+    let l:res = v:null
+    let l:did_int = 0
+
+    " Retry until Coqtop responds
+    while 1
+      try
+        let l:res = s:send_wait(self.handle, l:session, a:expr, 0)
+
+        " Handle requests
+        while type(l:res) == g:coqtail#compat#t_list && l:res[0] ==# 'call'
+          let l:val = call(l:res[1], l:res[2])
+          let l:res = s:send_wait(self.handle, l:session, l:val, l:res[-1])
+        endwhile
+      catch /^Vim:Interrupt$/
+        " Interrupt Coqtop and retry
+        if l:did_int
+          call coqtail#util#err('Coqtail is stuck. Try restarting to fix.')
+          return v:null
+        endif
+        let l:did_int = 1
+        call s:send_wait(self.handle, l:session, [a:expr[0], 'interrupt', {}], 0)
+        continue
+      endtry
+
+      return type(l:res) == g:coqtail#compat#t_list ? l:res[1] : v:null
+    endwhile
+  endfunction
+endif

--- a/autoload/coqtail/channel.vim
+++ b/autoload/coqtail/channel.vim
@@ -1,0 +1,117 @@
+" Author: Wolf Honore
+" Python communication channels.
+
+function! coqtail#channel#new(has_channel) abort
+  let l:chan = {'has_channel': a:has_channel, 'handle': -1}
+  let l:f_prefix = a:has_channel ? 'chan' : 'nochan'
+  for l:f in ['open', 'close', 'status', 'sendexpr', 'evalexpr']
+    let l:chan[l:f] = function(printf('s:%s_%s', l:f_prefix, l:f))
+  endfor
+  return l:chan
+endfunction
+
+" With +channel.
+function! s:chan_open(address, options) dict abort
+  let self.handle = ch_open(a:address, a:options)
+  return self.handle
+endfunction
+
+function! s:chan_close() dict abort
+  return ch_close(self.handle)
+endfunction
+
+function! s:chan_status() dict abort
+  return ch_status(self.handle)
+endfunction
+
+function! s:chan_sendexpr(expr, options) dict abort
+  return ch_sendexpr(self.handle, a:expr, a:options)
+endfunction
+
+function! s:chan_evalexpr(expr, options) dict abort
+  return ch_evalexpr(self.handle, a:expr, a:options)
+endfunction
+
+" With -channel.
+" Rate in ms to check if Coqtail is done computing.
+let s:poll_rate = 10
+
+" Unique session ID.
+let s:session = 0
+
+function! s:nochan_open(address, options) dict abort
+  let self.handle = coqtail#compat#pyeval(printf(
+    \ 'ChannelManager.open("%s")', a:address
+  \))
+  return self.handle
+endfunction
+
+function! s:nochan_close() dict abort
+  return coqtail#compat#pyeval(printf('ChannelManager.close(%d)', self.handle))
+endfunction
+
+function! s:nochan_status() dict abort
+  return coqtail#compat#pyeval(printf('ChannelManager.status(%d)', self.handle))
+endfunction
+
+function! s:nochan_sendexpr(expr, options) dict abort
+  echoerr 'Calling ch_sendexpr in synchronous mode.'
+endfunction
+
+" Send a command to Coqtail and wait for the response.
+function! s:send_wait(handle, session, expr, reply) abort
+  let l:returns = a:expr[1] !=# 'interrupt'
+  call coqtail#compat#pyeval(printf(
+    \ 'ChannelManager.send(%d, %s, %s, reply=%s, returns=bool(%s))',
+    \ a:handle,
+    \ a:expr[1] !=# 'interrupt' ? a:session : 'None',
+    \ json_encode(a:expr),
+    \ a:reply != 0 ? a:reply : 'None',
+    \ l:returns
+  \))
+
+  " Continually check if Coqtail is done computing
+  let l:poll = printf('ChannelManager.poll(%d)', a:handle)
+  while l:returns
+    let l:res = json_decode(coqtail#compat#pyeval(l:poll))
+    if type(l:res) == g:coqtail#compat#t_list
+      return l:res
+    endif
+
+    execute printf('sleep %dm', s:poll_rate)
+  endwhile
+
+  return v:null
+endfunction
+
+" Send a command to execute and reply to any requests from Coqtail.
+function! s:nochan_evalexpr(expr, options) dict abort
+  let s:session += 1
+  let l:session = s:session
+  let l:res = v:null
+  let l:did_int = 0
+
+  " Retry until Coqtop responds
+  while 1
+    try
+      let l:res = s:send_wait(self.handle, l:session, a:expr, 0)
+
+      " Handle requests
+      while type(l:res) == g:coqtail#compat#t_list && l:res[0] ==# 'call'
+        let l:val = call(l:res[1], l:res[2])
+        let l:res = s:send_wait(self.handle, l:session, l:val, l:res[-1])
+      endwhile
+    catch /^Vim:Interrupt$/
+      " Interrupt Coqtop and retry
+      if l:did_int
+        call coqtail#util#err('Coqtail is stuck. Try restarting to fix.')
+        return v:null
+      endif
+      let l:did_int = 1
+      call s:send_wait(self.handle, l:session, [a:expr[0], 'interrupt', {}], 0)
+      continue
+    endtry
+
+    return type(l:res) == g:coqtail#compat#t_list ? l:res[1] : v:null
+  endwhile
+endfunction

--- a/autoload/coqtail/compat.vim
+++ b/autoload/coqtail/compat.vim
@@ -1,0 +1,30 @@
+" Author: Wolf Honore
+" Python and Vim compatibility definitions.
+
+" Vim compatibility.
+let g:coqtail#compat#t_dict = type({})
+let g:coqtail#compat#t_list = type([])
+let g:coqtail#compat#has_channel = has('channel') && has('patch-8.0.0001')
+
+" Python compatibility.
+if has('python3')
+  command! -nargs=1 Py py3 <args>
+  function! coqtail#compat#pyeval(expr) abort
+    return py3eval(a:expr)
+  endfunction
+elseif has('python')
+  command! -nargs=1 Py py <args>
+  function! coqtail#compat#pyeval(expr) abort
+    return pyeval(a:expr)
+  endfunction
+else
+  echoerr 'Coqtail requires Python support.'
+  finish
+endif
+
+function! coqtail#compat#init(python_dir) abort
+  " Add python directory to path so Python functions can be called.
+  Py import sys, vim
+  Py if not vim.eval('a:python_dir') in sys.path:
+    \    sys.path.insert(0, vim.eval('a:python_dir'))
+endfunction

--- a/autoload/coqtail/compat.vim
+++ b/autoload/coqtail/compat.vim
@@ -17,14 +17,16 @@ elseif has('python')
   function! coqtail#compat#pyeval(expr) abort
     return pyeval(a:expr)
   endfunction
-else
-  echoerr 'Coqtail requires Python support.'
-  finish
 endif
 
 function! coqtail#compat#init(python_dir) abort
+  if !exists('*coqtail#compat#pyeval')
+    return 0
+  endif
+
   " Add python directory to path so Python functions can be called.
   Py import sys, vim
   Py if not vim.eval('a:python_dir') in sys.path:
     \    sys.path.insert(0, vim.eval('a:python_dir'))
+  return 1
 endfunction

--- a/autoload/coqtail/coqproject.vim
+++ b/autoload/coqtail/coqproject.vim
@@ -1,0 +1,54 @@
+" Author: Wolf Honore
+" Locate and parse _CoqProject files.
+
+Py import shlex
+
+" Parse a _CoqProject file into options that can be passed to Coqtop.
+function! coqtail#coqproject#parse(file) abort
+  let l:dir = fnamemodify(a:file, ':p:h')
+  let l:dir_opts = {'-R': 2, '-Q': 2, '-I': 1, '-include': 1}
+
+  let l:txt = join(readfile(a:file))
+  let l:raw_args = coqtail#compat#pyeval(printf('shlex.split(r%s)', string(l:txt)))
+
+  let l:proj_args = []
+  let l:idx = 0
+  while l:idx < len(l:raw_args)
+    " Make paths absolute for -R, -Q, etc
+    if has_key(l:dir_opts, l:raw_args[l:idx])
+      let l:absdir = l:raw_args[l:idx + 1]
+      if l:absdir[0] !=# '/'
+        " Join relative paths with 'l:dir'
+        let l:absdir = join([l:dir, l:absdir], '/')
+      endif
+      let l:raw_args[l:idx + 1] = fnamemodify(l:absdir, ':p')
+
+      " Can be '-R dir -as coqdir' in 8.4
+      let l:end = l:idx + l:dir_opts[l:raw_args[l:idx]]
+      if l:raw_args[l:end] ==# '-as' || get(l:raw_args, l:end + 1, '') ==# '-as'
+        let l:end = l:idx + 3
+      endif
+      let l:proj_args += l:raw_args[l:idx : l:end]
+      let l:idx = l:end
+    endif
+
+    " Pass through options following -arg
+    if l:raw_args[l:idx] ==# '-arg'
+      let l:proj_args = add(l:proj_args, l:raw_args[l:idx + 1])
+      let l:idx += 1
+    endif
+
+    let l:idx += 1
+  endwhile
+
+  return l:proj_args
+endfunction
+
+" Search for a CoqProject file using 'g:coqtail_project_name' starting in the
+" current directory and recursively try parent directories until '/' is
+" reached. Return the file name and a list of arguments to pass to Coqtop.
+function! coqtail#coqproject#locate() abort
+  let l:file = findfile(g:coqtail_project_name, '.;')
+  let l:args = l:file !=# '' ? coqtail#coqproject#parse(l:file) : []
+  return [l:file, l:args]
+endfunction

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -221,7 +221,6 @@ function! coqtail#panels#hide() abort
 endfunction
 
 " Refresh the highlighting and auxiliary panels.
-" TODO async: main-panel only
 function! coqtail#panels#refresh(buf, highlights, panels, scroll) abort
   if a:buf != bufnr('%')
     return

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -1,0 +1,260 @@
+" Author: Wolf Honore
+" Goal and Info panel management.
+
+" Unique suffix for auxiliary panel names.
+let s:counter = 0
+" Panel identifiers.
+let g:coqtail#panels#none = ''
+let g:coqtail#panels#main = 'main'
+let g:coqtail#panels#goal = 'goal'
+let g:coqtail#panels#info = 'info'
+let g:coqtail#panels#aux = [g:coqtail#panels#goal, g:coqtail#panels#info]
+" Highlighting groups.
+let g:coqtail#panels#hlgroups = [
+  \ ['coqtail_checked', 'CoqtailChecked'],
+  \ ['coqtail_sent', 'CoqtailSent'],
+  \ ['coqtail_error', 'CoqtailError']
+\]
+
+" Default panel layout.
+if !exists('g:coqtail_panel_layout')
+  let g:coqtail_panel_layout = {
+    \ g:coqtail#panels#goal:
+      \ [[g:coqtail#panels#info, 'above'], [g:coqtail#panels#main, 'right']],
+    \ g:coqtail#panels#info:
+      \ [[g:coqtail#panels#goal, 'below'], [g:coqtail#panels#main, 'right']]
+  \}
+endif
+
+" Default panel scroll options.
+if !exists('g:coqtail_panel_scroll')
+  let g:coqtail_panel_scroll = {
+    \ g:coqtail#panels#goal: 0,
+    \ g:coqtail#panels#info: 1
+  \}
+endif
+
+" Open and initialize goal/info panel.
+function! s:init(name) abort
+  let l:name = a:name . 's'
+  let l:bufname = substitute(a:name, '\l', '\u\0', '')
+
+  execute 'silent hide edit ' . l:bufname . s:counter
+  setlocal buftype=nofile
+  execute 'setlocal filetype=coq-' . l:name
+  setlocal noswapfile
+  setlocal bufhidden=hide
+  setlocal nocursorline
+  setlocal wrap
+
+  let b:coqtail_panel_open = 1
+  let b:coqtail_panel_size = [-1, -1]
+  return bufnr('%')
+endfunction
+
+" Create buffers for the auxiliary panels.
+function! coqtail#panels#init() abort
+  let l:main_buf = bufnr('%')
+  let l:curpos = getcurpos()[1:]
+  let l:coqtail_panel_bufs = {g:coqtail#panels#main: l:main_buf}
+
+  " Add panels
+  for l:panel in g:coqtail#panels#aux
+    let l:coqtail_panel_bufs[l:panel] = s:init(l:panel)
+  endfor
+  for l:buf in values(l:coqtail_panel_bufs)
+    call setbufvar(l:buf, 'coqtail_panel_bufs', l:coqtail_panel_bufs)
+  endfor
+
+  " Switch back to main panel
+  execute 'silent buffer ' . l:main_buf
+  call cursor(l:curpos)
+
+  let s:counter += 1
+endfunction
+
+" Detect what panel is focused.
+function! s:getcurpanel() abort
+  if !exists('b:coqtail_panel_bufs')
+    return g:coqtail#panels#none
+  endif
+
+  for [l:panel, l:buf] in items(b:coqtail_panel_bufs)
+    if l:buf == bufnr('%')
+      return l:panel
+    endif
+  endfor
+endfunction
+
+" Attempt to switch to a panel.
+function! coqtail#panels#switch(panel) abort
+  let l:cur_panel = s:getcurpanel()
+
+  if a:panel != l:cur_panel && a:panel != g:coqtail#panels#none
+    if !win_gotoid(win_getid(bufwinnr(b:coqtail_panel_bufs[a:panel])))
+      return g:coqtail#panels#none
+    endif
+  endif
+
+  return l:cur_panel
+endfunction
+
+" Open an auxiliary panel.
+function! s:open(panel, force) abort
+  let l:from = s:getcurpanel()
+  if l:from == g:coqtail#panels#none
+    return 0
+  endif
+
+  " Re-open only if not already open, it was open before, or 'force' is true
+  let l:opened = 0
+  let l:buf = b:coqtail_panel_bufs[a:panel]
+  if bufwinnr(l:buf) == -1 && (a:force || getbufvar(l:buf, 'coqtail_panel_open'))
+    " Arrange relative to the first open panel
+    for [l:relative, l:dir] in g:coqtail_panel_layout[a:panel]
+      if coqtail#panels#switch(l:relative) != g:coqtail#panels#none
+        let l:dir = l:dir ==# 'above' ? 'leftabove'
+          \ : l:dir ==# 'below' ? 'rightbelow'
+          \ : l:dir ==# 'left' ? 'vertical leftabove'
+          \ : l:dir ==# 'right' ? 'vertical rightbelow' : ''
+        if l:dir !=# ''
+          execute printf('silent %s sbuffer %d', l:dir, l:buf)
+          let b:coqtail_panel_open = 1
+          let l:opened = l:buf
+          break
+        endif
+      endif
+    endfor
+  endif
+
+  call coqtail#panels#switch(l:from)
+  return l:opened
+endfunction
+
+" Open auxiliary panels.
+function! coqtail#panels#open(force) abort
+  " Open
+  let l:opened = []
+  for l:panel in g:coqtail#panels#aux
+    if s:open(l:panel, a:force)
+      let l:opened = add(l:opened, l:panel)
+    endif
+  endfor
+
+  " Resize
+  for l:panel in l:opened
+    let l:buf = b:coqtail_panel_bufs[l:panel]
+    let l:win = bufwinnr(l:buf)
+    let l:size = getbufvar(l:buf, 'coqtail_panel_size')
+    if l:size != [-1, -1]
+      execute printf('vertical %dresize %d', l:win, l:size[0])
+      execute printf('%dresize %d', l:win, l:size[1])
+    endif
+  endfor
+endfunction
+
+" Scroll a panel up so text doesn't go off the top of the screen.
+function! s:scroll() abort
+  " Check if scrolling is necessary
+  let l:winh = winheight(0)
+  let l:disph = line('w$') - line('w0') + 1
+
+  " Scroll
+  if line('w0') != 1 && l:disph < l:winh
+    normal! Gz-
+  endif
+endfunction
+
+" Replace the contents of 'panel' with 'txt'.
+function! coqtail#panels#replace(panel, txt, scroll) abort
+  if coqtail#panels#switch(a:panel) == g:coqtail#panels#none
+    return
+  endif
+
+  " Save the view
+  let l:view = winsaveview()
+
+  " Update buffer text
+  silent %delete _
+  call append(0, a:txt)
+
+  " Restore the view
+  if !a:scroll || !g:coqtail_panel_scroll[a:panel]
+    call winrestview(l:view)
+  endif
+  call s:scroll()
+endfunction
+
+" Clear Coqtop highlighting.
+function! s:clearhl() abort
+  for [l:var, l:_] in g:coqtail#panels#hlgroups
+    if get(b:, l:var, -1) != -1
+      call matchdelete(b:[l:var])
+      let b:[l:var] = -1
+    endif
+  endfor
+endfunction
+
+" Close auxiliary panels and clear highlighting.
+function! coqtail#panels#hide() abort
+  if coqtail#panels#switch(g:coqtail#panels#main) == g:coqtail#panels#none
+    return
+  endif
+
+  call s:clearhl()
+
+  " Hide other panels
+  let l:toclose = []
+  for l:panel in g:coqtail#panels#aux
+    let l:buf = b:coqtail_panel_bufs[l:panel]
+    let l:win = bufwinnr(l:buf)
+    call setbufvar(l:buf, 'coqtail_panel_open', l:win != -1)
+    call setbufvar(l:buf, 'coqtail_panel_size', [winwidth(l:win), winheight(l:win)])
+    if l:win != -1
+      let l:toclose = add(l:toclose, l:buf)
+    endif
+  endfor
+
+  for l:buf in l:toclose
+    execute bufwinnr(l:buf) . 'close!'
+  endfor
+endfunction
+
+" Refresh the highlighting and auxiliary panels.
+" TODO async: main-panel only
+function! coqtail#panels#refresh(buf, highlights, panels, scroll) abort
+  if a:buf != bufnr('%')
+    return
+  endif
+  let l:win = win_getid()
+
+  " Update highlighting
+  call s:clearhl()
+  for [l:var, l:grp] in g:coqtail#panels#hlgroups
+    let l:hl = a:highlights[l:var]
+    if l:hl != v:null
+      let b:[l:var] = matchadd(l:grp, l:hl)
+    endif
+  endfor
+
+  " Update panels
+  try
+    for [l:panel, l:txt] in items(a:panels)
+      call coqtail#panels#replace(l:panel, l:txt, a:scroll)
+    endfor
+  finally
+    call win_gotoid(l:win)
+  endtry
+
+  redraw
+endfunction
+
+" Delete panel variables and clear highlighting.
+function! coqtail#panels#cleanup() abort
+  for l:panel in g:coqtail#panels#aux
+    silent! execute 'bdelete' . b:coqtail_panel_bufs[l:panel]
+  endfor
+  silent! unlet b:coqtail_panel_bufs
+
+  call s:clearhl()
+endfunction

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -229,9 +229,11 @@ endfunction
 " Refresh the highlighting and auxiliary panels.
 function! coqtail#panels#refresh(buf, highlights, panels, scroll) abort
   let l:win = bufwinnr(a:buf)
-  if l:win == -1
+  let l:refreshing = getbufvar(a:buf, 'coqtail_refreshing', 0)
+  if l:win == -1 || l:refreshing
     return
   endif
+  call setbufvar(a:buf, 'coqtail_refreshing', 1)
 
   let l:cur_win = win_getid()
   call win_gotoid(win_getid(l:win))
@@ -255,6 +257,7 @@ function! coqtail#panels#refresh(buf, highlights, panels, scroll) abort
   endtry
 
   redraw
+  call setbufvar(a:buf, 'coqtail_refreshing', 0)
 endfunction
 
 " Delete panel variables and clear highlighting.

--- a/autoload/coqtail/util.vim
+++ b/autoload/coqtail/util.vim
@@ -1,0 +1,51 @@
+" Author: Wolf Honore
+" Utility functions.
+
+" Print a message with warning highlighting.
+function! coqtail#util#warn(msg) abort
+  echohl WarningMsg | echom a:msg | echohl None
+endfunction
+
+" Print a message with error highlighting.
+function! coqtail#util#err(msg) abort
+  echohl ErrorMsg | echom a:msg | echohl None
+endfunction
+
+" Get the word under the cursor using the special '<cword>' variable. First
+" add some characters to the 'iskeyword' option to treat them as part of the
+" current word.
+function! coqtail#util#getcurword() abort
+  " Add '.' to definition of a keyword
+  let l:old_keywd = &iskeyword
+  setlocal iskeyword+=.
+
+  let l:cword = expand('<cword>')
+
+  " Strip trailing '.'s
+  let l:dotidx = match(l:cword, '[.]\+$')
+  if l:dotidx > -1
+    let l:cword = l:cword[: l:dotidx - 1]
+  endif
+
+  " Reset iskeyword
+  let &l:iskeyword = l:old_keywd
+
+  return l:cword
+endfunction
+
+" Remove entries in the quickfix list with the same position.
+function! coqtail#util#dedup_qflist() abort
+  let l:qfl = getqflist()
+  let l:seen = {}
+  let l:uniq = []
+
+  for l:entry in l:qfl
+    let l:pos = string([l:entry.lnum, l:entry.col])
+    if !has_key(l:seen, l:pos)
+      let l:seen[l:pos] = 1
+      let l:uniq = add(l:uniq, l:entry)
+    endif
+  endfor
+
+  call setqflist(l:uniq)
+endfunction

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -29,6 +29,10 @@ Starting and Stopping Coqtail				    *coqtail-start-stop*
 <leader>cq		Stop the plugin. Stop Coqtop and close the Goal and
 			Info panels.
 
+					*CTRL-C* *:CoqInterrupt* *coqtail-interrupt*
+:CoqInterrupt	or
+CTRL-C			Send SIGINT to Coqtop and clear any pending commands.
+
 =================
 Movement Commands					      *coqtail-movement*
 

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -3,10 +3,10 @@
 Author:  Wolf Honore
 License: MIT (see LICENSE)
 
-Coqtail provides an interface to the Coqtop program to allow interactive
-theorem proving. Coqtail uses a separate instance of Coqtop for each buffer, so
-you can have multiple Coq files open and switch between them seamlessly using
-the |arglist| or |buffer-list|.
+Coqtail provides an interface to Coqtop to enable interactive Coq proof
+development. Coqtail uses a separate instance of Coqtop for each buffer, so
+you can have multiple open Coq sessions and switch between them seamlessly
+using standard Vim methods (e.g., the |argument-list| or |buffer-list|).
 
 1. Starting and Stopping Coqtail	|coqtail-start-stop|
 2. Movement Commands			|coqtail-movement|
@@ -43,34 +43,34 @@ Movement Commands					      *coqtail-movement*
 			checking. If successful, highlight the sentences and
 			update the Goal and Info panels accordingly. Otherwise,
 			highlight the error and display the error message in
-			the Info panel. [count] defaults to 1.
+			the Info panel.
+
+			[count] default: 1.
 
 					      *<leader>ck* *i_<leader>ck* *:CoqUndo*
 								  *coqtail-undo*
 :[count]CoqUndo	or
 [count]<leader>ck	Rewind by [count] steps. Un-highlight the previous
-			sentences and update the Goal and Info panels. [count]
-			defaults to 1.
+			sentences and update the Goal and Info panels.
+
+			[count] default: 1.
 
 					    *<leader>cl* *i_<leader>cl* *:CoqToLine*
 							       *coqtail-to-line*
 :[count]CoqToLine or
-[count]<leader>cl	Check/rewind all sentences up to line [count]. If
-			multiple sentences end on the same line then check
-			until just past the last one. However, if no [count] is
-			given, use the cursor position instead, including the
-			column. For example, given the line below, where '^'
-			represents the cursor position, `:CoqToLine` would
-			position the end of the checked section just after '1'
-			whereas `:27CoqToLine` would put it after '2'. >
+[count]<leader>cl	Check/rewind all sentences up to the end of line
+			[count]. If no [count] is given, use the cursor
+			position instead. For example, given the line below,
+			where '^' represents the cursor position, `:CoqToLine`
+			will position the end of the checked section just after
+			'1' whereas `:27CoqToLine` will put it after '2'. >
     line 27:	   Let x := 1.^Let y := 2.
 <
 					     *<leader>cT* *i_<leader>cT* *:CoqToTop*
 								*coqtail-to-top*
 :CoqToTop	or
-<leader>cT		Rewind to the top of the file. Differs from
-			`:1CoqToLine` because it rewinds to the beginning of
-			the line.
+<leader>cT		Rewind to the top of the file. Unlike `:1CoqToLine`
+			it rewinds to the beginning of the line.
 
 						      *<leader>cG* *:CoqJumpToEnd*
 							   *coqtail-jump-to-end*
@@ -92,38 +92,30 @@ Movement Commands					      *coqtail-movement*
 Coq Queries						       *coqtail-queries*
 
 							    *:Coq* *coqtail-query*
-:Coq {args}		Send an arbitrary query to Coqtop. Some of the common
-			queries are listed below.
+:Coq {args}		Send an arbitrary query to Coqtop and write the
+			response to the Info panel. Commands and mappings for
+			the common queries are listed below.
 
 						     *<leader>cs* *coqtail-search*
 :Coq Search {arg}
-<leader>cs		Send the Search command to Coqtop. The first version
-			uses {arg}, while the second uses the term under the
-			cursor. Write the response to the Info panel.
+<leader>cs		The first version uses {arg}, while the second uses the
+			term under the cursor.
 
 						      *<leader>ch* *coqtail-check*
 :Coq Check {arg}
-<leader>ch		Send the Check command to Coqtop. The first version
-			uses {arg}, while the second uses the term under the
-			cursor. Write the response to the Info panel.
+<leader>ch
 
 						      *<leader>ca* *coqtail-about*
 :Coq About {arg}
-<leader>ca		Send the About command to Coqtop. The first version
-			uses {arg}, while the second uses the term under the
-			cursor. Write the response to the Info panel.
+<leader>ca
 
 						      *<leader>cp* *coqtail-print*
 :Coq Print {arg}
-<leader>cp		Send the Print command to Coqtop. The first version
-			uses {arg}, while the second uses the term under the
-			cursor. Write the response to the Info panel.
+<leader>cp
 
 						     *<leader>cf* *coqtail-locate*
 :Coq Locate {arg}
-<leader>cf		Send the Locate command to Coqtop. The first version
-			uses {arg}, while the second uses the term under the
-			cursor. Write the response to the Info panel.
+<leader>cf
 
 ================
 Panel Management						*coqtail-panels*
@@ -131,21 +123,23 @@ Panel Management						*coqtail-panels*
 						  *<leader>cr* *:CoqRestorePanels*
 							*coqtail-restore-panels*
 :CoqRestorePanels
-<leader>cr		Re-open the Goal and Info panels.
+<leader>cr		Re-open the Goal and Info panels in their original
+			configuration.
 
 						      *<leader>cgg* *:CoqGotoGoal*
 						       *coqtail-goto-goal-start*
 :[count]CoqGotoGoal
-<count><leader>cgg	Scroll the Goal panel to the start of goal [count]
-			defaulting to the first goal. Use |g:coqtail_goal_lines|
-			to decide which line to put at the bottom of the
-			panel.
+<count><leader>cgg	Scroll the Goal panel to the start of goal [count].
+			Control the number of goal lines to display with
+			|g:coqtail_goal_lines|.
+
+			[count] default: 1.
 
 						     *<leader>cGG* *:CoqGotoGoal!*
 							 *coqtail-goto-goal-end*
 :[count]CoqGotoGoal!
-<count><leader>cGG	Same as `:CoqGotoGoal` but put the last line of the
-			goal at the bottom of the panel.
+<count><leader>cGG	Same as `:CoqGotoGoal` but scroll to the end of the
+			goal.
 
 							   *g]* *:CoqGotoGoalNext*
 						  *coqtail-goto-goal-next-start*
@@ -174,7 +168,7 @@ Configuration						 *coqtail-configuration*
 				         *g:coqtail_coq_path* *b:coqtail_coq_path*
 							      *coqtail-coq-path*
 g:coqtail_coq_path
-b:coqtail_coq_path	The path to search for the Coqtop binary. If
+b:coqtail_coq_path	The path to search for the coq(ide)top(.opt) binary. If
 			empty then $PATH is used. The global variable is
 			checked only when the .v file is first loaded, but the
 			buffer-local variable is checked on every call to
@@ -189,10 +183,10 @@ g:coqtail_goal_lines	The number of lines from the start of a goal to
 			Default: 5.
 
 					     *b:coqtail_timeout* *coqtail-timeout*
-b:coqtail_timeout	The time in seconds before sending interrupting an
-			interrupt to Coqtop after issuing a command. A value of
-			0 disables the timeout. Coqtail can also be manually
-			interrupted with `:CoqInterrupt`.
+b:coqtail_timeout	The time in seconds before interrupting Coqtop after
+			issuing a command. A value of 0 disables the timeout.
+			Coqtail can also be manually interrupted with
+			`:CoqInterrupt`.
 
 			Default: 0
 
@@ -218,13 +212,13 @@ g:coqtail_nomap		If true then don't set any default mappings for
 			Default: 0
 
 					  *g:coqtail_nosyntax* *coqtail-no-syntax*
-g:coqtail_nosyntax	If true then don't use the syntax script included with
+g:coqtail_nosyntax	If true then don't load the syntax script included with
 			Coqtail.
 
 			Default: 0
 
 					  *g:coqtail_noindent* *coqtail-no-indent*
-g:coqtail_noindent	If true then don't use the indent script included with
+g:coqtail_noindent	If true then don't load the indent script included with
 			Coqtail.
 
 			Default: 0

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -175,31 +175,34 @@ Configuration						 *coqtail-configuration*
 							      *coqtail-coq-path*
 g:coqtail_coq_path
 b:coqtail_coq_path	The path to search for the Coqtop binary. If
-			|b:coqtail_coq_path| is empty then $PATH is used.
-			|g:coqtail_coq_path| defaults to "" and
-			|b:coqtail_coq_path| defaults to |g:coqtail_coq_path|.
-			The global variable is checked only once when the .v
-			file is first loaded, but the buffer-local variable is
-			checked on every call to `:CoqStart`.
+			empty then $PATH is used. The global variable is
+			checked only when the .v file is first loaded, but the
+			buffer-local variable is checked on every call to
+			`:CoqStart`.
+
+			Default: ''
 
 				       *g:coqtail_goal-lines* *coqtail-goal-lines*
 g:coqtail_goal_lines	The number of lines from the start of a goal to
-			display. Used by `:CoqGotoGoal`. Defaults to 5.
+			display. Used by `:CoqGotoGoal`.
+
+			Default: 5.
 
 					     *b:coqtail_timeout* *coqtail-timeout*
-b:coqtail_timeout	The time in seconds before a command sent to Coqtop
-			will be interrupted. Prevents vim from getting stuck if
-			Coqtop goes into an infinite loop. A value of 0
-			disables the timeout. Defaults to 0. Coq can also be
-			interrupted with CTRL-C.
+b:coqtail_timeout	The time in seconds before sending interrupting an
+			interrupt to Coqtop after issuing a command. A value of
+			0 disables the timeout. Coqtail can also be manually
+			interrupted with `:CoqInterrupt`.
+
+			Default: 0
 
 				       *g:coqtail_project_name* *coq-project-file*
-g:coqtail_project_name	The name of the Coq project file. Set to "_CoqProject"
-			by default. When it is started, Coqtail searches for
-			a file with this name starting from the current
-			directory up to the root directory. If one is found it
-			is parsed and the options are passed to Coqtop during
-			`:CoqStart`.
+g:coqtail_project_name	The name of the Coq project file to search for
+			beginning from the current directory up to the root.
+			If found, the project file options are parsed and
+			passed to Coqtop by `:CoqStart`.
+
+			Default: '_CoqProject'
 
 							*b:coqtail_project_file*
 b:coqtail_project_file	The path to the Coq project file. Set automatically if
@@ -207,22 +210,28 @@ b:coqtail_project_file	The path to the Coq project file. Set automatically if
 
 					    *g:coqtail_nomap* *coqtail-no-mapping*
 g:coqtail_nomap		If true then don't set any default mappings for
-			Coqtail	commands. Only specific mappings can also be
+			Coqtail	commands. Specific mappings can also be
 			overwritten by defining new mappings for the desired
 			commands. The defaults will continue to be used for the
 			rest.
+
+			Default: 0
 
 					  *g:coqtail_nosyntax* *coqtail-no-syntax*
 g:coqtail_nosyntax	If true then don't use the syntax script included with
 			Coqtail.
 
+			Default: 0
+
 					  *g:coqtail_noindent* *coqtail-no-indent*
 g:coqtail_noindent	If true then don't use the indent script included with
 			Coqtail.
 
+			Default: 0
+
 				     *g:coqtail_match_shift* *coqtail-match-shift*
 g:coqtail_match_shift	A multiple of 'shiftwidth' to indent lines in a match
-			branch. Defaults to 2. E.g. >
+			branch. E.g. >
 		    match b with
 		    | true =>
 		      1 (* g:coqtail_match_shift = 1 *)
@@ -230,12 +239,16 @@ g:coqtail_match_shift	A multiple of 'shiftwidth' to indent lines in a match
 			2 (* g:coqtail_match_shift = 2 *)
 		    end
 <
+			Default: 2
+
 				 *g:coqtail_indent_on_dot* *coqtail-indent-on-dot*
 g:coqtail_indent_on_dot	If true then trigger auto-indentation when a '.' is
-			typed. Defaults to false.
+			typed.
+
+			Default: 0
 
 							  *g:CoqtailHighlight()*
-g:CoqtailHighlight()	Optional function to overwrite the default highlighting
+g:CoqtailHighlight()	Optional function to override the default highlighting
 			for CoqtailChecked and CoqtailSent. E.g.  >
 		    function! g:CoqtailHighlight()
 		      hi def CoqtailChecked ctermbg=19
@@ -256,6 +269,7 @@ Debugging							 *coqtail-debug*
 					   *b:coqtail_log_name* *coqtail-log-name*
 b:coqtail_log_name	The name of the debugging log file. Set automatically
 			by enabling/disabling debugging with `:CoqToggleDebug`.
-			Defaults to ''.
+
+			Default: ''.
 
  vim:tw=78:ts=8:ft=help:norl:noet

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -11,7 +11,7 @@ the |arglist| or |buffer-list|.
 1. Starting and Stopping Coqtail	|coqtail-start-stop|
 2. Movement Commands			|coqtail-movement|
 3. Coq Queries				|coqtail-queries|
-4. Goal Focusing			|coqtail-goal-focus|
+4. Panel Management			|coqtail-panels|
 5. Configuration			|coqtail-configuration|
 6. Debugging				|coqtail-debug|
 
@@ -121,13 +121,18 @@ Coq Queries						       *coqtail-queries*
 			uses {arg}, while the second uses the term under the
 			cursor. Write the response to the Info panel.
 
-=============
-Goal Focusing						    *coqtail-goal-focus*
+================
+Panel Management						*coqtail-panels*
+
+						  *<leader>cr* *:CoqRestorePanels*
+							*coqtail-restore-panels*
+:CoqRestorePanels
+<leader>cr		Re-open the Goal and Info panels.
 
 						      *<leader>cgg* *:CoqGotoGoal*
 						       *coqtail-goto-goal-start*
 :[count]CoqGotoGoal
-<count><leader>cgg	Scroll the goal panel to the start of goal [count]
+<count><leader>cgg	Scroll the Goal panel to the start of goal [count]
 			defaulting to the first goal. Use |g:coqtail_goal_lines|
 			to decide which line to put at the bottom of the
 			panel.
@@ -141,23 +146,23 @@ Goal Focusing						    *coqtail-goal-focus*
 							   *g]* *:CoqGotoGoalNext*
 						  *coqtail-goto-goal-next-start*
 :CoqGotoGoalNext
-g]			Scroll the goal panel to the start of the next goal.
+g]			Scroll the Goal panel to the start of the next goal.
 
 							  *G]* *:CoqGotoGoalNext!*
 						    *coqtail-goto-goal-next-end*
 :CoqGotoGoalNext!
-G]			Scroll the goal panel to the end of the next goal.
+G]			Scroll the Goal panel to the end of the next goal.
 
 							   *g[* *:CoqGotoGoalPrev*
 						  *coqtail-goto-goal-prev-start*
 :CoqGotoGoalPrev
-g[			Scroll the goal panel to the start of the previous
+g[			Scroll the Goal panel to the start of the previous
 			goal.
 
 							  *G[* *:CoqGotoGoalPrev!*
 						    *coqtail-goto-goal-prev-end*
 :CoqGotoGoalPrev!
-G[			Scroll the goal panel to the end of the previous goal.
+G[			Scroll the Goal panel to the end of the previous goal.
 
 =============
 Configuration						 *coqtail-configuration*
@@ -240,7 +245,7 @@ Debugging							 *coqtail-debug*
 :CoqToggleDebug
 <leader>cd		Enable or disable logging of debugging statements to a
 			file. Enabling creates a temporary file and displays
-			the name in the info panel. The name is also stored in
+			the name in the Info panel. The name is also stored in
 			|b:coqtail_log_name|. Disabling and enabling again
 			creates a new log file. Disabled initially.
 

--- a/ftplugin/coq.vim
+++ b/ftplugin/coq.vim
@@ -4,7 +4,7 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
-call coqtail#Register()
+call coqtail#register()
 
 " Comments
 if has('comments')
@@ -16,7 +16,7 @@ if has('comments')
 endif
 
 " Follow imports
-setlocal includeexpr=coqtail#FindLib(v:fname)
+setlocal includeexpr=coqtail#findlib(v:fname)
 setlocal suffixesadd=.v
 setlocal include=\\<Require\\>\\(\\s*\\(Import\\\|Export\\)\\>\\)\\?
 
@@ -24,7 +24,7 @@ let b:undo_ftplugin = 'setl cms< com< fo< inex< sua< inc<'
 
 " Tags
 if exists('+tagfunc')
-  setlocal tagfunc=coqtail#GetTags
+  setlocal tagfunc=coqtail#gettags
   let b:undo_ftplugin .= ' | setl tfu<'
 endif
 

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -237,16 +237,12 @@ class Coqtail(object):
         return self.rewind_to(0, 1)
 
     def query(self, args):
-        # type: (List[Text]) -> Optional[str]
+        # type: (List[Text]) -> None
         """Forward Coq query to Coqtop interface."""
-        success, msg = self.do_query(" ".join(args))
-
-        if not success:
-            return unexpected(success, "query()")
+        _, msg = self.do_query(" ".join(args))
 
         self.set_info(msg)
         self.refresh(goals=False)
-        return None
 
     def endpoint(self):
         # type: () -> Tuple[int, int]

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -65,15 +65,10 @@ class Coqtail(object):
 
     def __init__(self, handler):
         # type: (CoqtailHandler) -> None
-        """Initialize variables."""
-        self.coqtop = None  # type: Optional[CT.Coqtop]
-        self.handler = handler
-        self._reset()
+        """Initialize variables.
 
-    def _reset(self):
-        # type: () -> None
-        """Reset variables to initial state.
-
+        coqtop - The Coqtop interface
+        handler - The Vim interface
         oldchange - The previous number of changes to the buffer
         oldbuf - The buffer corresponding to oldchange
         endpoints - A stack of the end positions of the sentences sent to Coqtop
@@ -83,6 +78,8 @@ class Coqtail(object):
         info_msg - The text to display in the info panel
         goal_msg - The text to display in the goal panel
         """
+        self.coqtop = None  # type: Optional[CT.Coqtop]
+        self.handler = handler
         self.oldchange = 0
         self.oldbuf = []  # type: List[Text]
         self.endpoints = []  # type: List[Tuple[int, int]]

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -816,7 +816,7 @@ class CoqtailHandler(StreamRequestHandler):
             self.coq.coqtop.interrupt()
 
 
-class CoqtailServer:
+class CoqtailServer(object):
     """A server through which Vim and Coqtail communicate."""
 
     serv = None
@@ -921,7 +921,8 @@ class ChannelManager(object):
                 _ = json.loads(res)
                 ChannelManager.results[handle] = res
                 break
-            except json.JSONDecodeError:
+            # Python 2 doesn't have json.JSONDecodeError
+            except ValueError:
                 pass
 
 

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -100,13 +100,17 @@ class Coqtail(object):
                 eline, ecol = self.endpoints[-1]
                 linediff = _find_diff(self.oldbuf, newbuf, eline + 1)
                 if linediff is not None:
-                    coldiff = _find_diff(
-                        self.oldbuf[linediff],
-                        newbuf[linediff],
-                        ecol if linediff == eline else None,
-                    )
+                    try:
+                        coldiff = _find_diff(
+                            self.oldbuf[linediff],
+                            newbuf[linediff],
+                            ecol if linediff == eline else None,
+                        )
+                    except IndexError:
+                        linediff = len(newbuf) - 1
+                        coldiff = len(newbuf[-1])
                     if coldiff is not None:
-                        err = self.rewind_to(linediff, coldiff)
+                        err = self.rewind_to(linediff, coldiff + 1)
 
             self.oldchange = newchange
             self.oldbuf = newbuf

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -678,7 +678,7 @@ class CoqtailHandler(StreamRequestHandler):
     """Forward messages between Vim and Coqtail."""
 
     # Redraw rate in seconds
-    refresh_rate = 0.1
+    refresh_rate = 0.05
 
     # How often to check for a closed channel
     check_close_rate = 1
@@ -804,9 +804,10 @@ class CoqtailHandler(StreamRequestHandler):
             cur_time = time.time()
             force = cur_time - self.refresh_time > self.refresh_rate
             self.refresh_time = cur_time
-        self.vimcall(
-            "coqtail#Refresh", self.bnum, force, self.coq.highlights, self.coq.panels
-        )
+        if force:
+            self.vimcall(
+                "coqtail#Refresh", self.bnum, self.coq.highlights, self.coq.panels
+            )
 
 
 serv = None

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -1,6 +1,6 @@
 # -*- coding: utf8 -*-
 # Author: Wolf Honore
-"""Classes and functions for managing goal and info panels and Coqtop interfaces."""
+"""Classes and functions for managing auxiliary panels and Coqtop interfaces."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -61,7 +61,7 @@ class NoDotError(Exception):
 
 # Coqtail Server #
 class Coqtail(object):
-    """Manage Coqtop interfaces and goal and info buffers for each Coq file."""
+    """Manage Coqtop interfaces and auxiliary buffers for each Coq file."""
 
     def __init__(self, handler):
         # type: (CoqtailHandler) -> None
@@ -423,7 +423,7 @@ class Coqtail(object):
     # Goals and Infos #
     def refresh(self, goals=True, force=True):
         # type: (bool, bool) -> None
-        """Refresh the goal and info panels."""
+        """Refresh the auxiliary panels."""
         if goals:
             newgoals, newinfo = self.get_goals()
             if newinfo != "":
@@ -544,7 +544,7 @@ class Coqtail(object):
         matches = {
             "coqtail_checked": None,
             "coqtail_sent": None,
-            "coqtail_errors": None,
+            "coqtail_error": None,
         }  # type: Dict[str, Optional[str]]
 
         if self.endpoints != []:
@@ -565,7 +565,7 @@ class Coqtail(object):
 
         if self.error_at is not None:
             (sline, scol), (eline, ecol) = self.error_at
-            matches["coqtail_errors"] = _make_matcher(
+            matches["coqtail_error"] = _make_matcher(
                 (sline + 1, scol), (eline + 1, ecol)
             )
 
@@ -573,7 +573,7 @@ class Coqtail(object):
 
     def panels(self, goals=True):
         # type: (bool) -> Mapping[str, List[Text]]
-        """The goal and info panel content."""
+        """The auxiliary panel content."""
         panels = {"info": self.info_msg}
         if goals:
             panels["goal"] = self.goal_msg
@@ -806,7 +806,7 @@ class CoqtailHandler(StreamRequestHandler):
 
     def refresh(self, goals=True, force=True):
         # type: (bool, bool) -> None
-        """Refresh the highlighting and goal and info panels."""
+        """Refresh the highlighting and auxiliary panels."""
         if not force:
             cur_time = time.time()
             force = cur_time - self.refresh_time > self.refresh_rate

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -16,7 +16,7 @@ from itertools import islice
 
 from six.moves import zip_longest
 from six.moves.queue import Empty, Queue
-from six.moves.socketserver import StreamRequestHandler, TCPServer, ThreadingMixIn
+from six.moves.socketserver import StreamRequestHandler, ThreadingTCPServer
 
 import coqtop as CT
 
@@ -655,10 +655,6 @@ class Coqtail(object):
         return self.handler.vimcall("getbufline", self.handler.bnum, 1, "$")  # type: ignore
 
 
-class ThreadedTCPServer(ThreadingMixIn, TCPServer):
-    """Create a thread for each client."""
-
-
 class CoqtailHandler(StreamRequestHandler):
     """Forward messages between Vim and Coqtail."""
 
@@ -830,9 +826,8 @@ class CoqtailServer:
         # type: () -> int
         """Start the TCP server."""
         # N.B. port = 0 chooses any arbitrary open one
-        CoqtailServer.serv = ThreadedTCPServer(("localhost", 0), CoqtailHandler)
-        # Mypy isn't aware of this attribute on ThreadingMixin
-        CoqtailServer.serv.daemon_threads = True  # type: ignore
+        CoqtailServer.serv = ThreadingTCPServer(("localhost", 0), CoqtailHandler)
+        CoqtailServer.serv.daemon_threads = True
         _, port = CoqtailServer.serv.server_address
 
         serv_thread = threading.Thread(target=CoqtailServer.serv.serve_forever)

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -829,6 +829,8 @@ def start_server():
     # N.B. port = 0 chooses any arbitrary open one
     global serv
     serv = ThreadedTCPServer(("localhost", 0), CoqtailHandler)
+    # Mypy isn't aware of this attribute on ThreadingMixin
+    serv.daemon_threads = True  # type: ignore
     _, port = serv.server_address
 
     serv_thread = threading.Thread(target=serv.serve_forever)
@@ -838,7 +840,6 @@ def start_server():
     return port
 
 
-# TODO async: call this to shutdown cleanly
 def stop_server():
     # type: () -> None
     """Stop the TCP server."""

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -782,6 +782,11 @@ class CoqtailHandler(StreamRequestHandler):
             #     stop = time.time()
             #     print('done to_line', round(stop - start, 2))
 
+            try:
+                del self.resps[self.msg_id]
+            except KeyError:
+                pass
+
             if func == "stop":
                 break
 

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -768,19 +768,12 @@ class CoqtailHandler(StreamRequestHandler):
                 "refresh": self.coq.refresh,
             }.get(func, None)
 
-            # if func == 'to_line':
-            #     start = time.time()
-
             try:
                 ret = handler(**args) if handler is not None else None  # type: ignore
             except EOFError:
                 break
             msg = [self.msg_id, {"buf": self.bnum, "ret": ret}]
             self.wfile.write(json.dumps(msg).encode("utf-8"))
-
-            # if func == 'to_line':
-            #     stop = time.time()
-            #     print('done to_line', round(stop - start, 2))
 
             try:
                 del self.resps[self.msg_id]

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -431,7 +431,7 @@ class Coqtail(object):
                 self.set_goal(self.pp_goals(newgoals))
             else:
                 self.set_goal("")
-        self.handler.refresh(force=force)
+        self.handler.refresh(goals=goals, force=force)
 
     def get_goals(self):
         # type: () -> Tuple[Optional[Tuple[List[Any], List[Any], List[Any], List[Any]]], Text]
@@ -570,11 +570,13 @@ class Coqtail(object):
 
         return matches
 
-    @property
-    def panels(self):
-        # type: () -> Mapping[str, List[Text]]
+    def panels(self, goals=True):
+        # type: (bool) -> Mapping[str, List[Text]]
         """The goal and info panel content."""
-        return {"goal": self.goal_msg, "info": self.info_msg}
+        panels = {"info": self.info_msg}
+        if goals:
+            panels["goal"] = self.goal_msg
+        return panels
 
     def splash(self, version, width, height):
         # type: (Text, int, int) -> None
@@ -793,8 +795,8 @@ class CoqtailHandler(StreamRequestHandler):
         else:
             return self.vimcall("setbufvar", self.bnum, var, val)
 
-    def refresh(self, force=True):
-        # type: (bool) -> None
+    def refresh(self, goals=True, force=True):
+        # type: (bool, bool) -> None
         """Refresh the highlighting and goal and info panels."""
         if not force:
             cur_time = time.time()
@@ -802,7 +804,10 @@ class CoqtailHandler(StreamRequestHandler):
             self.refresh_time = cur_time
         if force:
             self.vimcall(
-                "coqtail#Refresh", self.bnum, self.coq.highlights, self.coq.panels
+                "coqtail#Refresh",
+                self.bnum,
+                self.coq.highlights,
+                self.coq.panels(goals),
             )
 
 

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -767,7 +767,7 @@ class CoqtailHandler(StreamRequestHandler):
                 break
 
     def vimeval(self, expr, wait=True):
-        # type: (List[Any]) -> Any
+        # type: (List[Any], bool) -> Any
         """Send Vim a request."""
         self.wfile.write(json.dumps(expr + [-self.msg_id]).encode("utf-8"))
 
@@ -778,7 +778,7 @@ class CoqtailHandler(StreamRequestHandler):
         return None
 
     def vimcall(self, expr, wait, *args):
-        # type: (str, *Any) -> Any
+        # type: (str, bool, *Any) -> Any
         """Request Vim to evaluate a function call."""
         return self.vimeval(["call", expr, args], wait=wait)
 

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -40,6 +40,9 @@ except ImportError:
 
 
 # Error Messages #
+COQTOP_ERR = "Coqtop is not running. Please restart and try again."
+
+
 def unexpected(response, where):
     # type: (Any, str) -> str
     """Create a debugging error about an unexpected response."""
@@ -178,7 +181,8 @@ class Coqtail(object):
     def rewind(self, steps, opts):
         # type: (int, Mapping[str, Any]) -> Optional[str]
         """Rewind Coq by 'steps' sentences."""
-        assert self.coqtop is not None
+        if self.coqtop is None:
+            return COQTOP_ERR
 
         if steps < 1 or self.endpoints == []:
             return None
@@ -262,7 +266,8 @@ class Coqtail(object):
     def send_until_fail(self, buffer, opts):
         # type: (Sequence[Text], Mapping[str, Any]) -> Tuple[Optional[Tuple[int, int]], Optional[str]]
         """Send all sentences in 'send_queue' until an error is encountered."""
-        assert self.coqtop is not None
+        if self.coqtop is None:
+            return None, COQTOP_ERR
 
         scroll = len(self.send_queue) > 1
         failed_at = None
@@ -320,7 +325,8 @@ class Coqtail(object):
     def do_query(self, query, opts):
         # type: (Text, Mapping[str, Any]) -> Tuple[bool, Text]
         """Execute a query and return the reply."""
-        assert self.coqtop is not None
+        if self.coqtop is None:
+            return False, COQTOP_ERR
 
         # Ensure that the query ends in '.'
         if not query.endswith("."):
@@ -444,7 +450,8 @@ class Coqtail(object):
     def get_goals(self, opts):
         # type: (Mapping[str, Any]) -> Tuple[Optional[Tuple[List[Any], List[Any], List[Any], List[Any]]], Text]
         """Get the current goals."""
-        assert self.coqtop is not None
+        if self.coqtop is None:
+            return None, COQTOP_ERR
 
         try:
             success, msg, goals = self.coqtop.goals(timeout=opts["timeout"])
@@ -616,9 +623,10 @@ class Coqtail(object):
         self.info_msg = top_pad + msg
 
     def toggle_debug(self, opts):
-        # type: (Mapping[str, Any]) -> None
+        # type: (Mapping[str, Any]) -> Optional[str]
         """Enable or disable logging of debug messages."""
-        assert self.coqtop is not None
+        if self.coqtop is None:
+            return COQTOP_ERR
 
         log = self.coqtop.toggle_debug()
         if log is None:
@@ -630,6 +638,7 @@ class Coqtail(object):
 
         self.set_info(msg)
         self.refresh(goals=False, opts=opts)
+        return None
 
     # Vim Helpers #
     @property

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -672,6 +672,9 @@ class CoqtailHandler(StreamRequestHandler):
     # Is a request currently being handled
     working = False
 
+    # Is the client synchronous
+    sync = False
+
     def parse_msgs(self):
         # type: () -> None
         """Parse messages sent over a Vim channel."""
@@ -800,7 +803,7 @@ class CoqtailHandler(StreamRequestHandler):
         if force:
             self.vimcall(
                 "coqtail#panels#refresh",
-                False,
+                self.sync,
                 self.bnum,
                 self.coq.highlights,
                 self.coq.panels(goals),
@@ -826,10 +829,11 @@ class CoqtailServer(object):
     serv = None
 
     @staticmethod
-    def start_server():
-        # type: () -> int
+    def start_server(sync):
+        # type: (bool) -> int
         """Start the TCP server."""
         # N.B. port = 0 chooses any arbitrary open one
+        CoqtailHandler.sync = sync
         CoqtailServer.serv = ThreadingTCPServer(("localhost", 0), CoqtailHandler)
         CoqtailServer.serv.daemon_threads = True
         _, port = CoqtailServer.serv.server_address

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -593,8 +593,8 @@ class Coqtail(object):
             panels["goal"] = self.goal_msg
         return panels
 
-    def splash(self, version, width, height, opts):
-        # type: (Text, int, int, Mapping[str, Any]) -> None
+    def splash(self, version, width, height, deprecated, opts):
+        # type: (Text, int, int, bool, Mapping[str, Any]) -> None
         """Display the logo in the info panel."""
         msg = [
             u"~~~~~~~~~~~~~~~~~~~~~~~",
@@ -618,8 +618,11 @@ class Coqtail(object):
         msg_maxw = max(len(line) for line in msg)
         msg = [line.center(width - msg_maxw // 2) for line in msg]
 
-        top_pad = [u""] * ((height // 2) - (len(msg) // 2 + 1))
+        if deprecated:
+            depr_msg = u"Support for Python 2 is deprecated and will be dropped in an upcoming version."
+            msg += [u"", depr_msg.center(width - msg_maxw // 2)]
 
+        top_pad = [u""] * ((height // 2) - (len(msg) // 2 + 1))
         self.info_msg = top_pad + msg
 
     def toggle_debug(self, opts):

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -799,7 +799,7 @@ class CoqtailHandler(StreamRequestHandler):
             self.refresh_time = cur_time
         if force:
             self.vimcall(
-                "coqtail#Refresh",
+                "coqtail#panels#refresh",
                 self.bnum,
                 self.coq.highlights,
                 self.coq.panels(goals),

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -767,11 +767,11 @@ class CoqtailHandler(StreamRequestHandler):
 
             try:
                 ret = handler(**args) if handler is not None else None  # type: ignore
-            except EOFError:
+                msg = [self.msg_id, {"buf": self.bnum, "ret": ret}]
+                self.wfile.write(json.dumps(msg).encode("utf-8"))
+            # Python 2 doesn't have BrokenPipeError
+            except (EOFError, OSError):
                 break
-
-            msg = [self.msg_id, {"buf": self.bnum, "ret": ret}]
-            self.wfile.write(json.dumps(msg).encode("utf-8"))
 
             try:
                 del self.resps[self.msg_id]

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -678,14 +678,12 @@ class CoqtailHandler(StreamRequestHandler):
         while not self.closed:
             try:
                 msg = self.rfile.readline().decode("utf-8")
+                msg_id, data = json.loads(msg)
             except ValueError:
-                msg = ""
-            # Check if channel closed
-            if msg == "":
+                # Check if channel closed
                 self.closed = True
                 break
 
-            msg_id, data = json.loads(msg)
             if msg_id >= 0:
                 bnum, func, args = data
                 if func == "interrupt":

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -772,7 +772,9 @@ class CoqtailHandler(StreamRequestHandler):
     def vimeval(self, expr, wait=True):
         # type: (List[Any], bool) -> Any
         """Send Vim a request."""
-        self.wfile.write(json.dumps(expr + [-self.msg_id]).encode("utf-8"))
+        if wait:
+            expr += [-self.msg_id]
+        self.wfile.write(json.dumps(expr).encode("utf-8"))
 
         if wait:
             msg_id, res = self.get_msg(self.msg_id)

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -18,7 +18,7 @@ from tempfile import NamedTemporaryFile
 from six import ensure_text
 from six.moves.queue import Empty, Queue
 
-from xmlInterface import Err, Ok, STOPPED_ERR, TIMEOUT_ERR, XMLInterface, prettyxml
+from xmlInterface import Err, Ok, TIMEOUT_ERR, XMLInterface, prettyxml
 
 # For Mypy
 try:
@@ -362,7 +362,6 @@ class Coqtop(object):
         # Start threads and wait for Coqtop to finish
         timeout_thread.start()
         answer_thread.start()
-        stopped = False
 
         # Notify timeout_thread that a response is received and wait for
         # threads to finish
@@ -372,11 +371,8 @@ class Coqtop(object):
 
         # Check for user interrupt or timeout
         response = res_ref.val
-        if isinstance(response, Err):
-            if stopped:
-                response = STOPPED_ERR
-            elif timed_out.is_set():
-                response = TIMEOUT_ERR
+        if isinstance(response, Err) and timed_out.is_set():
+            response = TIMEOUT_ERR
 
         return self.xml.standardize(cmd, response)
 

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -49,10 +49,6 @@ class Err(object):
         self.loc = loc
 
 
-# The error in case of a user interrupt
-STOPPED_ERR = Err("Coq interrupted.")
-
-
 # The error in case of a timeout
 TIMEOUT_ERR = Err(
     "Coq timed out. You can change the timeout with <leader>ct and try again."

--- a/tests/coq_project.vader
+++ b/tests/coq_project.vader
@@ -1,15 +1,18 @@
+Before (initialize):
+  call coqtail#compat#init('../python/')
+
 Execute (dot):
   let f = tempname()
   let d = fnamemodify(f, ':p:h')
   call writefile(['-R . top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', d . '/', 'top'], args
 
 Execute (absolute-cwd):
   let f = tempname()
   let d = fnamemodify(f, ':p:h')
   call writefile(['-R ' . d . ' top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', d . '/', 'top'], args
 
 Execute (relative-subdir):
@@ -19,7 +22,7 @@ Execute (relative-subdir):
   let dsd = join([d, sd], '/')
   call mkdir(dsd)
   call writefile(['-R ' . sd . ' top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', dsd . '/', 'top'], args
 
 Execute (relative-dot-subdir):
@@ -29,7 +32,7 @@ Execute (relative-dot-subdir):
   let dsd = join([d, sd], '/')
   call mkdir(dsd)
   call writefile(['-R ./' . sd . ' top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', dsd . '/', 'top'], args
 
 Execute (absolute-subdir):
@@ -39,7 +42,7 @@ Execute (absolute-subdir):
   let dsd = join([d, sd], '/')
   call mkdir(dsd)
   call writefile(['-R ' . dsd . ' top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', dsd . '/', 'top'], args
 
 Execute (sibling-dir):
@@ -52,56 +55,56 @@ Execute (sibling-dir):
   call mkdir(dsd1)
   call mkdir(dsd2)
   call writefile(['-R ../' . sd2 . ' top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', dsd2 . '/', 'top'], args
 
 Execute (split-line):
   let f = tempname()
   let d = fnamemodify(f, ':p:h')
   call writefile(['-R', '.', 'top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', d . '/', 'top'], args
 
 Execute (multi-option-diff-lines):
   let f = tempname()
   let d = fnamemodify(f, ':p:h')
   call writefile(['-R . top', '-Q . top2'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', d . '/', 'top', '-Q', d . '/', 'top2'], args
 
 Execute (multi-option-same-line):
   let f = tempname()
   let d = fnamemodify(f, ':p:h')
   call writefile(['-R . top -Q . top2'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', d . '/', 'top', '-Q', d . '/', 'top2'], args
 
 Execute (extra-whitespace):
   let f = tempname()
   let d = fnamemodify(f, ':p:h')
   call writefile([' -R  .  top '], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', d . '/', 'top'], args
 
 Execute (alternate-R):
   let f = tempname()
   let d = fnamemodify(f, ':p:h')
   call writefile(['-R . -as top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', d . '/', '-as', 'top'], args
 
 Execute (I):
   let f = tempname()
   let d = fnamemodify(f, ':p:h')
   call writefile(['-I . -R . top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-I', d . '/', '-R', d . '/', 'top'], args
 
 Execute (alternate-I):
   let f = tempname()
   let d = fnamemodify(f, ':p:h')
   call writefile(['-include . -I . -as top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-include', d . '/', '-I', d . '/', '-as', 'top'], args
 
 Execute (expand-space):
@@ -111,7 +114,7 @@ Execute (expand-space):
   call mkdir(dsd, 'p')
   let f = join([dsd, '1'], '/')
   call writefile(['-R . top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', dsd . '/', 'top'], args
 
 Execute (quote-space):
@@ -121,7 +124,7 @@ Execute (quote-space):
   call mkdir(dsd, 'p')
   let f = join([dsd, '1'], '/')
   call writefile(['-R "' . dsd . '" top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', dsd . '/', 'top'], args
 
 Execute (quote-strip):
@@ -131,14 +134,14 @@ Execute (quote-strip):
   call mkdir(dsd, 'p')
   let f = join([dsd, '1'], '/')
   call writefile(['-R "' . dsd . '" top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', dsd . '/', 'top'], args
 
 Execute (quote-empty):
   let f = tempname()
   let d = fnamemodify(f, ':p:h')
   call writefile(['-R . ""'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', d . '/', ''], args
 
 Execute (quote-escape):
@@ -150,17 +153,17 @@ Execute (quote-escape):
   call mkdir(dsd, 'p')
   let f = join([dsd, '1'], '/')
   call writefile(['-R "' . dsdEsc . '" top'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-R', dsd . '/', 'top'], args
 
 Execute (arg):
   let f = tempname()
   call writefile(['-arg -w -arg all'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['-w', 'all'], args
 
 Execute (ignore-files):
   let f = tempname()
   call writefile(['-arg a', '-byte', 'A.v'], f)
-  let args = coqtail#ParseCoqProj(f, 1)
+  let args = coqtail#coqproject#parse(f)
   AssertEqual ['a'], args

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -20,7 +20,6 @@ import pytest
 
 # Mock vim modules
 sys.modules["vim"] = Mock()
-sys.modules["vimbufsync"] = Mock()
 from coqtail import _get_message_range, _strip_comments, NoDotError, UnmatchedError
 
 # Test Values #

--- a/tox.ini
+++ b/tox.ini
@@ -22,13 +22,12 @@ commands_pre =
     coq{84,85,86,87,88,89,810,811,master}: {toxinidir}/ci/install-coq.sh {envname} {envtmpdir}
 
     vim: git clone https://github.com/junegunn/vader.vim {envtmpdir}/vader.vim
-    vim: git clone https://github.com/let-def/vimbufsync {envtmpdir}/vimbufsync
 
 commands =
 ; setenv doesn't seem to be enough to pick up the right Coq version
     pytest: sh -c 'PATH={env:PATH} {envpython} -m pytest -q {posargs}'
 
-    vim: sh -c 'echo "filetype off | set rtp+={envtmpdir}/vader.vim | set rtp+={envtmpdir}/vimbufsync | set rtp+=. | filetype plugin indent on | syntax enable" > {envtmpdir}/vimrc'
+    vim: sh -c 'echo "filetype off | set rtp+={envtmpdir}/vader.vim | set rtp+=. | filetype plugin indent on | syntax enable" > {envtmpdir}/vimrc'
     vim: vim -Nu {envtmpdir}/vimrc -c 'Vader! tests/*.vader'
 
 [testenv:devbase]


### PR DESCRIPTION
- [x] Make all calls from Vim to Coqtail use `ch_sendexpr` (#11)
- [x] Add a synchronous fallback for Vim without channels
- [x] Fix interrupting with Ctrl-C
- [x] Make buffer read-only while handling commands
- [x] Performance tuning
- [x] Ensure reasonable behavior when
  - [x] User switches buffers while running
  - [x] Channel is closed
  - [x] Coq is killed
  - [x] Vim is killed
- [x] Test with Vim 7.4-8.2
- [x] Test with Python 2
- [x] Fix tests