### PR TITLE
Define a tagfunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Coqtail provides the following commands (see `:help coqtail` for more details):
 | `{n}CoqToLine` | `<leader>cl` | Check/rewind all sentences up to line `n` (cursor position by default). `n` can also be `$` to check the entire buffer.|
 | `CoqToTop` | `<leader>cT` | Rewind to the beginning of the file. Similar to `1CoqToLine`, but `CoqToLine` only rewinds to the end of the line. |
 | `CoqJumpToEnd` | `<leader>cG` | Move the cursor to the end of the checked region. |
-| `CoqGotoDef[!] <arg>` | `<leader>cg` | Populate the quickfix list with possible locations of the definition of `<arg>` and try to jump to the first one. |
+| `CoqGotoDef[!] <arg>` | `<leader>cg` | Populate the quickfix list with possible locations of the definition of `<arg>` and try to jump to the first one. If your Vim supports `'tagfunc'` you can just use `CTRL-]`, `:tag`, and friends instead. |
 | **Queries** | |
 | `Coq <args>` | | Send arbitrary queries to Coq (e.g. `Check`, `About`, `Print`, etc.). |
 | `Coq Check <arg>` | `<leader>ch` | Show the type of `<arg>` (the mapping will use the term under the cursor). |

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -322,9 +322,10 @@ endfunction
 function! s:findDef(target) abort
   if !b:coqtail_running
     return v:null
-  else
-    let l:loc = s:pyeval("Coqtail().find_def(vim.eval('a:target')) or []")()
-    return l:loc == [] ? v:null : l:loc
+  endif
+
+  let l:loc = s:pyeval("Coqtail().find_def(vim.eval('a:target')) or []")()
+  return l:loc == [] ? v:null : l:loc
 endfunction
 
 " Populate the quickfix list with possible locations of the definition of
@@ -332,7 +333,7 @@ endfunction
 function! coqtail#GotoDef(target, bang) abort
   let l:bang = a:bang ? '!' : ''
   let l:loc = s:findDef(a:target)
-  if l:loc is v:null
+  if type(l:loc) != type([])
     call s:warn('Cannot locate ' . a:target . '.')
     return
   endif
@@ -368,14 +369,15 @@ endfunction
 " Create a list of tags for 'target'.
 function! coqtail#GetTags(target, flags, info) abort
   let l:loc = s:findDef(a:target)
-  if l:loc is v:null
+  if type(l:loc) != type([])
     return v:null
   endif
   let [l:path, l:searches] = l:loc
 
   let l:tags = []
   for l:search in l:searches
-    let l:tags = add(l:tags, {'name': a:target, 'filename': l:path, 'cmd': '/\v' . l:search})
+    let l:tag = {'name': a:target, 'filename': l:path, 'cmd': '/\v' . l:search}
+    let l:tags = add(l:tags, l:tag)
   endfor
 
   return l:tags

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -82,6 +82,8 @@ Movement Commands					      *coqtail-movement*
 			the first one. If jumping is impossible open the
 			|quickfix-window| instead. The first version uses
 			{arg}, while the second uses the term under the cursor.
+			If |'tagfunc'| is supported then the usual tag
+			commands will also work (|:tag|, |CTRL-]|, etc).
 
 ===========
 Coq Queries						       *coqtail-queries*

--- a/ftplugin/coq.vim
+++ b/ftplugin/coq.vim
@@ -16,6 +16,11 @@ setlocal includeexpr=coqtail#FindLib(v:fname)
 setlocal suffixesadd=.v
 setlocal include=\\<Require\\>\\(\\s*\\(Import\\\|Export\\)\\>\\)\\?
 
+" Tags
+if exists('+tagfunc')
+  setlocal tagfunc=coqtail#GetTags
+endif
+
 " matchit/matchup patterns
 if (exists('loaded_matchit') || exists('loaded_matchup')) && !exists('b:match_words')
   let b:match_ignorecase = 0
@@ -30,4 +35,3 @@ if (exists('loaded_matchit') || exists('loaded_matchup')) && !exists('b:match_wo
   \ '\%(\<Section\>\|\<Module\>\):\<End\>',
   \ s:proof_start . ':' . s:proof_end
   \], ',')
-endif

--- a/ftplugin/coq.vim
+++ b/ftplugin/coq.vim
@@ -35,3 +35,4 @@ if (exists('loaded_matchit') || exists('loaded_matchup')) && !exists('b:match_wo
   \ '\%(\<Section\>\|\<Module\>\):\<End\>',
   \ s:proof_start . ':' . s:proof_end
   \], ',')
+endif


### PR DESCRIPTION
Use the same method for searching for definitions as in `GotoDef` to define a `tagfunc` so `:tag`, etc work without a tagfile.