### PR TITLE
Specify nix version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: nix
+nix: 2.3.6
 
 matrix:
   include:


### PR DESCRIPTION
Fixes "This version of Nixpkgs requires Nix >= 2.2, please upgrade" error in Travis.