### PR TITLE
check before calling coqtail#stop on QuitPre

### DIFF
--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -361,7 +361,7 @@ function! coqtail#start(...) abort
       autocmd BufWinLeave <buffer> call coqtail#panels#hide()
       autocmd BufWinEnter <buffer>
         \ call coqtail#panels#open(0) | call s:call('refresh', '', {})
-      autocmd QuitPre <buffer> call coqtail#stop()
+      autocmd QuitPre <buffer> if len(win_findbuf(expand('<abuf>'))) == 1 | call coqtail#stop() | endif
     augroup END
   endif
 


### PR DESCRIPTION
There might be multiple windows showing the current buffer. So calling `coqtail#stop` might be called even if I don't intend to stop the coq process. Using `BufDelete` seems to be a better for this type of functionality.