### PR TITLE
Fix install Coq master using Cachix in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
     - env: TOXENV=vim
 
 install:
+  # Need CI to be a trusted user for cachix
+  # https://github.com/travis-ci/travis-build/pull/1833#issuecomment-651013953
+  - if [[ $TOXENV =~ coqmaster ]]; then echo "trusted-users = $USER" | sudo tee -a /etc/nix/nix.conf; sudo systemctl restart nix-daemon; fi
   - if [[ $TOXENV =~ py27 ]]; then PY=27; else PY=36; fi
   - nix-env -j auto -iA nixpkgs.python${PY}Packages.virtualenv
   - virtualenv venv

--- a/ci/install-coq.sh
+++ b/ci/install-coq.sh
@@ -6,6 +6,7 @@ if [ -z "$outdir" ]; then exit 1; fi
 outdir="$outdir/coq"
 
 function master {
+    echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
     path=$(nix-prefetch-url --unpack 'https://github.com/coq/coq-on-cachix/tarball/master' --name source --print-path | tail -n1)
     nix-build -j auto "$path" --extra-substituters "https://coq.cachix.org" --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI=" -o "$outdir"
     exit

--- a/ci/install-coq.sh
+++ b/ci/install-coq.sh
@@ -6,10 +6,8 @@ if [ -z "$outdir" ]; then exit 1; fi
 outdir="$outdir/coq"
 
 function master {
-    echo "substituters = https://cache.nixos.org https://coq.cachix.org" | sudo tee -a /etc/nix/nix.conf
-    echo "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI=" | sudo tee -a /etc/nix/nix.conf
     path=$(nix-prefetch-url --unpack 'https://github.com/coq/coq-on-cachix/tarball/master' --name source --print-path | tail -n1)
-    nix-build -j auto "$path" -o "$outdir"
+    nix-build -j auto "$path" --extra-substituters "https://coq.cachix.org" --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI=" -o "$outdir"
     exit
 }
 

--- a/ci/install-coq.sh
+++ b/ci/install-coq.sh
@@ -6,9 +6,10 @@ if [ -z "$outdir" ]; then exit 1; fi
 outdir="$outdir/coq"
 
 function master {
-    echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
+    echo "substituters = https://cache.nixos.org https://coq.cachix.org" | sudo tee -a /etc/nix/nix.conf
+    echo "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI=" | sudo tee -a /etc/nix/nix.conf
     path=$(nix-prefetch-url --unpack 'https://github.com/coq/coq-on-cachix/tarball/master' --name source --print-path | tail -n1)
-    nix-build -j auto "$path" --extra-substituters "https://coq.cachix.org" --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI=" -o "$outdir"
+    nix-build -j auto "$path" -o "$outdir"
     exit
 }
 


### PR DESCRIPTION
Travis switched to using multi-user Nix installs, which broke Cachix.
https://github.com/travis-ci/travis-build/pull/1833#issuecomment-651013953