### PR TITLE
Add preliminary 8.13 support

### DIFF
--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -1280,8 +1280,18 @@ class XMLInterface812(XMLInterface811):
             res.val = opts
         return res
 
+class XMLInterface813(XMLInterface812):
+    """The version 8.13.* XML interface."""
 
-XMLInterfaceLatest = XMLInterface812
+    def __init__(self, versions):
+        # type: (Tuple[int, ...]) -> None
+        """Update launch arguments."""
+        super(XMLInterface812, self).__init__(versions)
+
+        # Unclear why this makes things work when building locally with dune
+        self.coqtop = "coqidetop.opt"
+
+XMLInterfaceLatest = XMLInterface813
 
 
 def XMLInterface(version):
@@ -1315,5 +1325,7 @@ def XMLInterface(version):
         return XMLInterface810(versions)
     elif (8, 11, 0) <= versions < (8, 12, 0):
         return XMLInterface811(versions)
+    elif (8, 12, 0) <= versions < (8, 13, 0):
+        return XMLInterface812(versions)
     else:
         return XMLInterfaceLatest(versions)


### PR DESCRIPTION
Note that the coqidetop binary seems to have been moved into a different directory, so I am running coqtail with both directories in `PATH`, `env PATH="$HOME/coq/_build/install/default/bin:$HOME/coq/_build/default/ide/coqide:$PATH" COQLIB="$HOME/coq/_build/install/default/lib/coq" vim /tmp/a.v`. I am not sure how an installed coq 8.13 would need to be called.

As it seems that coqtail has coq master on its CI now, perhaps coqtail could be added to Coq CI ([procedure](https://github.com/coq/coq/blob/master/dev/ci/README-users.md#information-for-external-library--coq-plugin-authors)) to put backpressure on this kind of breakage?