### PR TITLE
set nobuflisted for aux panels

### DIFF
--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -46,6 +46,7 @@ function! s:init(name) abort
   execute 'setlocal filetype=coq-' . l:name
   setlocal noswapfile
   setlocal bufhidden=hide
+  setlocal nobuflisted
   setlocal nocursorline
   setlocal wrap
 


### PR DESCRIPTION
Info/Goal buffers don't need to listed by `:ls` or `:Buffers` from fzf.vim.