### PR TITLE
Add proof diffs to Coqtail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased ([master])
 
 ### Added
+- Support for highlighting proof diffs.
+  `g:coqtail_auto_set_proof_diffs` can be used to automatically enable diffs on
+  `:CoqStart`.
+  (PR #169)
 - Support for multiple `_CoqProject` files. **BREAKING**: renamed
   `g:coqtail_project_name` to `g:coqtail_project_names` and
   `b:coqtail_project_file` to `b:coqtail_project_files`. (PR #141)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,26 @@ These scripts are used by default but can be disabled by setting
 `g:coqtail_nosyntax = 1` and `g:coqtail_noindent = 1` respectively.
 Formatting of comments can be disabled with `g:coqtail_noindent_comment`.
 
+### Proof Diffs
+
+Since 8.9, Coq can generate
+[proof diffs](https://coq.inria.fr/distrib/current/refman/proofs/writing-proofs/proof-mode.html#coq:opt.Diffs)
+to highlight the differences in the proof context between successive steps.
+To enable proof diffs manually, use `:Coq Set Diffs "on"`.
+To automatically enable proof diffs on every `:CoqStart`, set
+`g:coqtail_auto_set_proof_diffs = "on"`.
+By default, Coqtail highlights these diffs as follows:
+
+```vim
+hi def link CoqtailDiffAdded DiffText
+hi def link CoqtailDiffAddedBg DiffChange
+hi def link CoqtailDiffRemoved DiffDelete
+hi def link CoqtailDiffRemovedBg DiffDelete
+```
+
+To override these settings simply set your own colors for these highlighting
+groups before `syntax/coq.vim` is sourced (e.g., in your `.vimrc`).
+
 See `:help coqtail-configuration` for more configuration variables.
 
 ## Vim Plugin Interoperability

--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ Formatting of comments can be disabled with `g:coqtail_noindent_comment`.
 
 ### Proof Diffs
 
-Since 8.9, Coq can generate
-[proof diffs](https://coq.inria.fr/distrib/current/refman/proofs/writing-proofs/proof-mode.html#coq:opt.Diffs)
-to highlight the differences in the proof context between successive steps.
-To enable proof diffs manually, use `:Coq Set Diffs "on"`.
+Since 8.9, Coq can generate [proof diffs] to highlight the differences in the
+proof context between successive steps.
+To enable proof diffs manually, use `:Coq Set Diffs "on"` or `:Coq Set Diffs
+"removed"`.
 To automatically enable proof diffs on every `:CoqStart`, set
-`g:coqtail_auto_set_proof_diffs = "on"`.
+`g:coqtail_auto_set_proof_diffs = 'on'` (or `= 'removed'`).
 By default, Coqtail highlights these diffs as follows:
 
 ```vim
@@ -193,5 +193,6 @@ See [YouCompleteMe] for help building Vim with Python 3 support.
 [matchup]: https://github.com/andymass/vim-matchup
 [matchit]: http://ftp.vim.org/pub/vim/runtime/macros/matchit.txt
 [endwise]: https://github.com/tpope/vim-endwise
+[proof diffs]: https://coq.inria.fr/distrib/current/refman/proofs/writing-proofs/proof-mode.html#coq:opt.Diffs
 [Coquille]: https://github.com/the-lambda-church/coquille
 [YouCompleteMe]: https://github.com/ycm-core/YouCompleteMe/wiki/Building-Vim-from-source

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -406,6 +406,10 @@ function! coqtail#start(...) abort
       \ 'deprecated': has('python')})
     call s:call('refresh', '', 0, {})
 
+    if coqtail#util#getvar([b:, g:], 'coqtail_proof_diffs', 0)
+      call s:call("query", "", 0, {"args": ["Set", "Diffs", '"on"' ]})
+    endif
+
     " Sync edits to the buffer, close and restore the auxiliary panels
     augroup coqtail#Sync
       autocmd! * <buffer>
@@ -415,6 +419,7 @@ function! coqtail#start(...) abort
         \ call coqtail#panels#open(0) | call s:call('refresh', '', 0, {})
       autocmd WinNew <buffer> call s:call('refresh', '', 0, {})
     augroup END
+
   endif
 
   return 1

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -285,7 +285,7 @@ endfunction
 
 " Enable proof diffs upon starting
 function! s:init_proof_diffs(coq_version) abort
-    let l:proof_diffs_arg = coqtail#util#getvar([b:, g:], 'coqtail_auto_enable_proof_diffs', '')
+    let l:proof_diffs_arg = coqtail#util#getvar([b:, g:], 'coqtail_auto_set_proof_diffs', '')
     if l:proof_diffs_arg ==# ''
       return
     endif

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -291,7 +291,9 @@ function! s:init_proof_diffs(coq_version) abort
     endif
 
     if coqtail#version#atleast(a:coq_version, '8.9.*')
-      call s:call('query', '', 0, {'args': ['Set', 'Diffs', '"' . l:proof_diffs_arg . '"']})
+      call s:call('query', '', 0, {
+        \ 'args': ['Set', 'Diffs', '"' . l:proof_diffs_arg . '"'],
+        \ 'silent': 1})
     endif
 endfunction
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -283,6 +283,18 @@ function! s:call(cmd, cb, nocoq, args) abort
   endif
 endfunction
 
+" Enable proof diffs upon starting
+function! s:init_proof_diffs(coq_version) abort
+    let l:proof_diffs_arg = coqtail#util#getvar([b:, g:], 'coqtail_auto_enable_proof_diffs', "")
+    if l:proof_diffs_arg == ""
+      return
+    endif
+
+    if coqtail#version#atleast(a:coq_version, '8.9.*')
+      call s:call("query", "", 0, {"args": ["Set", "Diffs", '"' . l:proof_diffs_arg . '"' ]})
+    endif
+endfunction
+
 " Print any error messages.
 function! coqtail#defaultCB(chan, msg) abort
   let l:pending = getbufvar(a:msg.buf, 'coqtail_cmds_pending')
@@ -384,9 +396,7 @@ function! coqtail#start(...) abort
       \ 'deprecated': has('python')})
     call s:call('refresh', '', 0, {})
 
-    if coqtail#util#getvar([b:, g:], 'coqtail_proof_diffs', 0)
-      call s:call("query", "", 0, {"args": ["Set", "Diffs", '"on"' ]})
-    endif
+    call s:init_proof_diffs(b:coqtail_version)
 
     " Sync edits to the buffer, close and restore the auxiliary panels
     augroup coqtail#Sync

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -285,13 +285,13 @@ endfunction
 
 " Enable proof diffs upon starting
 function! s:init_proof_diffs(coq_version) abort
-    let l:proof_diffs_arg = coqtail#util#getvar([b:, g:], 'coqtail_auto_enable_proof_diffs', "")
-    if l:proof_diffs_arg == ""
+    let l:proof_diffs_arg = coqtail#util#getvar([b:, g:], 'coqtail_auto_enable_proof_diffs', '')
+    if l:proof_diffs_arg ==# ''
       return
     endif
 
     if coqtail#version#atleast(a:coq_version, '8.9.*')
-      call s:call("query", "", 0, {"args": ["Set", "Diffs", '"' . l:proof_diffs_arg . '"' ]})
+      call s:call('query', '', 0, {'args': ['Set', 'Diffs', '"' . l:proof_diffs_arg . '"']})
     endif
 endfunction
 
@@ -407,7 +407,6 @@ function! coqtail#start(...) abort
         \ call coqtail#panels#open(0) | call s:call('refresh', '', 0, {})
       autocmd WinNew <buffer> call s:call('refresh', '', 0, {})
     augroup END
-
   endif
 
   return 1

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -293,7 +293,7 @@ function! s:call(cmd, cb, nocoq, args) abort
   endif
 endfunction
 
-" Enable proof diffs upon starting
+" Enable proof diffs upon starting.
 function! s:init_proof_diffs(coq_version) abort
     let l:proof_diffs_arg = coqtail#util#getvar([b:, g:], 'coqtail_auto_set_proof_diffs', '')
     if l:proof_diffs_arg ==# ''

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -241,10 +241,8 @@ function! s:replace(buf, panel, txt, richpp, scroll) abort
   " Set new highlights
   let l:matches = []
   for [l:line_no, l:start_pos, l:span, l:hlgroup] in a:richpp
-    echom 'wee hooo ' . l:hlgroup
     if has_key(s:richpp_hlgroups, l:hlgroup)
       let l:match = matchaddpos(s:richpp_hlgroups[l:hlgroup], [[l:line_no, l:start_pos, l:span]])
-      echom 'Added highlight (' . l:hlgroup . '): ' . string(l:line_no) . ' ' . string(l:start_pos) . ' ' . string(l:span)
       call add(l:matches, l:match)
     endif
   endfor

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -58,7 +58,7 @@ function! s:init(name) abort
 
   let b:coqtail_panel_open = 1
   let b:coqtail_panel_size = [-1, -1]
-  call setbufvar(bufnr('%'), 'coqtail_panel_richpp', [])
+  let b:coqtail_panel_richpp = []
   return bufnr('%')
 endfunction
 
@@ -230,7 +230,7 @@ function! s:replace(buf, panel, txt, richpp, scroll) abort
   let l:view = winsaveview()
 
   " Remove previous highlights
-  for l:match in getbufvar(bufnr('%'), 'coqtail_panel_richpp')
+  for l:match in b:coqtail_panel_richpp
     call matchdelete(l:match)
   endfor
 
@@ -247,7 +247,7 @@ function! s:replace(buf, panel, txt, richpp, scroll) abort
     endif
   endfor
 
-  call setbufvar(bufnr('%'), 'coqtail_panel_richpp', l:matches)
+  let b:coqtail_panel_richpp = l:matches
 
   " Restore the view
   if !a:scroll || !g:coqtail_panel_scroll[a:panel]

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -15,6 +15,12 @@ let s:hlgroups = [
   \ ['coqtail_sent', 'CoqtailSent'],
   \ ['coqtail_error', 'CoqtailError']
 \]
+let s:richpp_hlgroups = {
+      \ 'diff.added': 'CoqtailDiffAdded',
+      \ 'diff.removed': 'CoqtailDiffRemoved',
+      \ 'diff.added.bg': 'CoqtailDiffAddedBg',
+      \ 'diff.removed.bg': 'CoqtailDiffRemovedBg',
+      \}
 
 " Default panel layout.
 if !exists('g:coqtail_panel_layout')
@@ -52,6 +58,7 @@ function! s:init(name) abort
 
   let b:coqtail_panel_open = 1
   let b:coqtail_panel_size = [-1, -1]
+  call setbufvar(bufnr('%'), 'coqtail_panel_richpp', [])
   return bufnr('%')
 endfunction
 
@@ -214,7 +221,7 @@ function! coqtail#panels#hide() abort
 endfunction
 
 " Replace the contents of 'panel' with 'txt'.
-function! s:replace(buf, panel, txt, scroll) abort
+function! s:replace(buf, panel, txt, richpp, scroll) abort
   if s:switch_from(a:buf, a:panel) == g:coqtail#panels#none
     return
   endif
@@ -222,9 +229,27 @@ function! s:replace(buf, panel, txt, scroll) abort
   " Save the view
   let l:view = winsaveview()
 
+  " Remove previous highlights
+  for l:match in getbufvar(bufnr('%'), 'coqtail_panel_richpp')
+    call matchdelete(l:match)
+  endfor
+
   " Update buffer text
   silent %delete _
   call append(0, a:txt)
+
+  " Set new highlights
+  let l:matches = []
+  for [l:line_no, l:start_pos, l:span, l:hlgroup] in a:richpp
+    echom 'wee hooo ' . l:hlgroup
+    if has_key(s:richpp_hlgroups, l:hlgroup)
+      let l:match = matchaddpos(s:richpp_hlgroups[l:hlgroup], [[l:line_no, l:start_pos, l:span]])
+      echom 'Added highlight (' . l:hlgroup . '): ' . string(l:line_no) . ' ' . string(l:start_pos) . ' ' . string(l:span)
+      call add(l:matches, l:match)
+    endif
+  endfor
+
+  call setbufvar(bufnr('%'), 'coqtail_panel_richpp', l:matches)
 
   " Restore the view
   if !a:scroll || !g:coqtail_panel_scroll[a:panel]
@@ -259,8 +284,9 @@ function! coqtail#panels#refresh(buf, highlights, panels, scroll) abort
     endfor
 
     " Update panels
-    for [l:panel, l:txt] in items(a:panels)
-      call s:replace(a:buf, l:panel, l:txt, a:scroll)
+    for [l:panel, l:panel_data] in items(a:panels)
+      let [l:txt, l:richpp] = l:panel_data
+      call s:replace(a:buf, l:panel, l:txt, l:richpp, a:scroll)
     endfor
   catch /^Vim:Interrupt$/
   finally

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -16,11 +16,11 @@ let s:hlgroups = [
   \ ['coqtail_error', 'CoqtailError']
 \]
 let s:richpp_hlgroups = {
-      \ 'diff.added': 'CoqtailDiffAdded',
-      \ 'diff.removed': 'CoqtailDiffRemoved',
-      \ 'diff.added.bg': 'CoqtailDiffAddedBg',
-      \ 'diff.removed.bg': 'CoqtailDiffRemovedBg',
-      \}
+  \ 'diff.added': 'CoqtailDiffAdded',
+  \ 'diff.removed': 'CoqtailDiffRemoved',
+  \ 'diff.added.bg': 'CoqtailDiffAddedBg',
+  \ 'diff.removed.bg': 'CoqtailDiffRemovedBg'
+\}
 
 " Default panel layout.
 if !exists('g:coqtail_panel_layout')
@@ -243,10 +243,9 @@ function! s:replace(buf, panel, txt, richpp, scroll) abort
   for [l:line_no, l:start_pos, l:span, l:hlgroup] in a:richpp
     if has_key(s:richpp_hlgroups, l:hlgroup)
       let l:match = matchaddpos(s:richpp_hlgroups[l:hlgroup], [[l:line_no, l:start_pos, l:span]])
-      call add(l:matches, l:match)
+      let l:matches = add(l:matches, l:match)
     endif
   endfor
-
   let b:coqtail_panel_richpp = l:matches
 
   " Restore the view

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -280,6 +280,14 @@ g:CoqtailHighlight()	Optional function to override the default highlighting
 		      hi def CoqtailSent ctermbg=62
 		    endfunction
 <
+				         *g:coqtail_proof_diffs* *b:coqtail_proof_diffs*
+							      *coqtail-proof-diffs*
+g:coqtail_proof_diffs
+b:coqtail_proof_diffs	If true then turn on proof diffs for each Coqtail
+			buffer.
+
+			Default: 0
+
 =========
 Debugging							 *coqtail-debug*
 

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -285,17 +285,17 @@ g:CoqtailHighlight()	Optional function to override the default highlighting
 							   *coqtail-proof-diffs*
 g:coqtail_auto_set_proof_diffs
 b:coqtail_auto_set_proof_diffs
-			An argument to automatically enable proof diffs with
-			`:Coq Set Diffs` on every new Coqtail session. For
-			example, if `g:coqtail_auto_set_proof_diffs` is `'on'`
-			then `:CoqStart` calls `:Coq Set Diffs "on"`
-			immediately after launching Coqtop. The argument is
-			ignored if it is set to `''` (the default) or if using
-			a version of Coq that does not support proof diffs.
+			The argument to automatically pass to `:Coq Set Diffs`
+			on every new Coqtail session. For example, if
+			`g:coqtail_auto_set_proof_diffs` is `'on'` then
+			`:CoqStart` calls `:Coq Set Diffs "on"` immediately
+			after launching Coqtop. The argument is ignored if it
+			is set to `''` (the default) or if using a version of
+			Coq that does not support proof diffs.
 			Note: Changing this option after `:CoqStart` has no
-			effect on the current proof. To manually toggle
-			diffs mid-proof use `:Coq Set Diffs "{arg}"` where
-			`{arg}` is `on`, `off`, or `removed`.
+			effect on the current proof. To manually toggle diffs
+			mid-proof use `:Coq Set Diffs "{arg}"` where `{arg}` is
+			`on`, `off`, or `removed`.
 
 			Default: ''
 

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -280,13 +280,24 @@ g:CoqtailHighlight()	Optional function to override the default highlighting
 		      hi def CoqtailSent ctermbg=62
 		    endfunction
 <
-				         *g:coqtail_proof_diffs* *b:coqtail_proof_diffs*
-							      *coqtail-proof-diffs*
-g:coqtail_proof_diffs
-b:coqtail_proof_diffs	If true then turn on proof diffs for each Coqtail
-			buffer.
+						*g:coqtail_auto_set_proof_diffs*
+						*b:coqtail_auto_set_proof_diffs*
+							   *coqtail-proof-diffs*
+g:coqtail_auto_set_proof_diffs
+b:coqtail_auto_set_proof_diffs
+			An argument to automatically enable proof diffs with
+			`:Coq Set Diffs` on every new Coqtail session. For
+			example, if `g:coqtail_auto_set_proof_diffs` is `'on'`
+			then `:CoqStart` calls `:Coq Set Diffs "on"`
+			immediately after launching Coqtop. The argument is
+			ignored if it is set to `''` (the default) or if using
+			a version of Coq that does not support proof diffs.
+			Note: Changing this option after `:CoqStart` has no
+			effect on the current proof. To manually toggle
+			diffs mid-proof use `:Coq Set Diffs "{arg}"` where
+			`{arg}` is `on`, `off`, or `removed`.
 
-			Default: 0
+			Default: ''
 
 =========
 Debugging							 *coqtail-debug*
@@ -303,6 +314,6 @@ Debugging							 *coqtail-debug*
 b:coqtail_log_name	The name of the debugging log file. Set automatically
 			by enabling/disabling debugging with `:CoqToggleDebug`.
 
-			Default: ''.
+			Default: ''
 
  vim:tw=78:ts=8:ft=help:norl:noet

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -27,8 +27,8 @@ try:
         DefaultDict,
         Deque,
         Dict,
-        Iterator,
         Iterable,
+        Iterator,
         List,
         Mapping,
         Optional,
@@ -60,9 +60,12 @@ def lines_and_highlights(tagged_tokens, line_no):
     if isinstance(tagged_tokens, string_types):
         return tagged_tokens.splitlines(), []
 
-    lines, highlights = [], [] # type: Tuple[List[Text], List[Tuple[int, int, int, str]]]
-    line_no += 1 # Convert to 1-indexed per matchaddpos()'s spec
-    line, index = '', 1
+    lines, highlights = (
+        [],
+        [],
+    )  # type: Tuple[List[Text], List[Tuple[int, int, int, str]]]
+    line_no += 1  # Convert to 1-indexed per matchaddpos()'s spec
+    line, index = "", 1
 
     for token, tag in tagged_tokens:
         for i, tok in enumerate(token.splitlines()):
@@ -70,9 +73,9 @@ def lines_and_highlights(tagged_tokens, line_no):
                 # Encountered a newline in token
                 lines.append(line)
                 line_no += 1
-                line, index = '', 1
+                line, index = "", 1
 
-            tok_len = len(tok.encode('utf-8'))
+            tok_len = len(tok.encode("utf-8"))
             if tag is not None:
                 highlights.append((line_no, index, tok_len, tag))
 
@@ -502,7 +505,10 @@ class Coqtail(object):
     def pp_goals(self, goals, opts):
         # type: (Tuple[List[Any], List[Any], List[Any], List[Any]], Mapping[str, Any]) -> Tuple[List[Text], List[Tuple[int, int, int, str]]]
         """Pretty print the goals."""
-        lines, highlights = [], [] # type: Tuple[List[Text], List[Tuple[int, int, int, str]]]
+        lines, highlights = (
+            [],
+            [],
+        )  # type: Tuple[List[Text], List[Tuple[int, int, int, str]]]
         fg, bg, shelved, given_up = goals
         bg_joined = [pre + post for pre, post in bg]
 
@@ -587,7 +593,7 @@ class Coqtail(object):
         """Update the goal message."""
         if msg is not None:
             self.goal_msg, self.goal_hls = msg
-        if ''.join(self.goal_msg) == '':
+        if "".join(self.goal_msg) == "":
             self.goal_msg, self.goal_hls = ["No goals."], []
 
     def set_info(self, msg=None, reset=True):
@@ -634,7 +640,9 @@ class Coqtail(object):
     def panels(self, goals=True):
         # type: (bool) -> Mapping[str, Tuple[List[Text], List[Tuple[int, int, int, str]]]]
         """The auxiliary panel content."""
-        panels = {"info": (self.info_msg, [])} # type: Dict[str, Tuple[List[Text], List[Tuple[int, int, int, str]]]]
+        panels = {
+            "info": (self.info_msg, [])
+        }  # type: Dict[str, Tuple[List[Text], List[Tuple[int, int, int, str]]]]
         if goals:
             panels["goal"] = (self.goal_msg, self.goal_hls)
         return panels

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -13,6 +13,7 @@ from collections import defaultdict as ddict
 from collections import deque
 from itertools import islice
 
+from six import string_types
 from six.moves import zip_longest
 from six.moves.queue import Empty, Queue
 from six.moves.socketserver import StreamRequestHandler, ThreadingTCPServer
@@ -56,8 +57,8 @@ def lines_and_highlights(tagged_tokens, line_no):
 
     # If tagged_tokens turns out to already be a string (which is the case for
     # older versions of Coq), just return it as is, with no highlights.
-    if not isinstance(tagged_tokens, list):
-        return tagged_tokens.splitlines(), [] # type: ignore
+    if isinstance(tagged_tokens, string_types):
+        return tagged_tokens.splitlines(), []
 
     lines, highlights = [], [] # type: Tuple[List[Text], List[Tuple[int, int, int, str]]]
     line_no += 1 # Convert to 1-indexed per matchaddpos()'s spec
@@ -557,12 +558,9 @@ class Coqtail(object):
                 lines.append("")
                 lines.append(next_info)
 
-                if isinstance(next_goal.ccl, Text):
-                    lines.append(next_goal.ccl)
-                else:
-                    ls, hls = lines_and_highlights(next_goal.ccl, len(lines))
-                    lines += ls
-                    highlights += hls
+                ls, hls = lines_and_highlights(next_goal.ccl, len(lines))
+                lines += ls
+                highlights += hls
 
             else:
                 lines.append("All goals completed.")

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -56,8 +56,8 @@ def lines_and_highlights(tagged_tokens, line_no):
 
     # If tagged_tokens turns out to already be a string (which is the case for
     # older versions of Coq), just return it as is, with no highlights.
-    if isinstance(tagged_tokens, Text):
-        return tagged_tokens.splitlines(), []
+    if not isinstance(tagged_tokens, list):
+        return tagged_tokens.splitlines(), [] # type: ignore
 
     lines, highlights = [], [] # type: Tuple[List[Text], List[Tuple[int, int, int, str]]]
     line_no += 1 # Convert to 1-indexed per matchaddpos()'s spec

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -60,9 +60,9 @@ def lines_and_highlights(tagged_tokens, line_no):
         return tagged_tokens.splitlines(), []
 
     lines = []  # type: List[Text]
-    highlights = []  # type: List[Tuple[int, int, int, str]]
+    highlights = []  # type: List[Tuple[int, int, int, Text]]
     line_no += 1  # Convert to 1-indexed per matchaddpos()'s spec
-    line, index = "", 1
+    line, index = u"", 1
 
     for token, tag in tagged_tokens:
         for i, tok in enumerate(token.splitlines()):
@@ -126,7 +126,7 @@ class Coqtail(object):
         self.error_at = None  # type: Optional[Tuple[Tuple[int, int], Tuple[int, int]]]
         self.info_msg = []  # type: List[Text]
         self.goal_msg = []  # type: List[Text]
-        self.goal_hls = []  # type: List[Tuple[int, int, int, str]]
+        self.goal_hls = []  # type: List[Tuple[int, int, int, Text]]
 
     def sync(self, opts):
         # type: (Mapping[str, Any]) -> Optional[str]
@@ -500,10 +500,10 @@ class Coqtail(object):
         return goals, msg
 
     def pp_goals(self, goals, opts):
-        # type: (Tuple[List[Any], List[Any], List[Any], List[Any]], Mapping[str, Any]) -> Tuple[List[Text], List[Tuple[int, int, int, str]]]
+        # type: (Tuple[List[Any], List[Any], List[Any], List[Any]], Mapping[str, Any]) -> Tuple[List[Text], List[Tuple[int, int, int, Text]]]
         """Pretty print the goals."""
         lines = []  # type: List[Text]
-        highlights = []  # type: List[Tuple[int, int, int, str]]
+        highlights = []  # type: List[Tuple[int, int, int, Text]]
         fg, bg, shelved, given_up = goals
         bg_joined = [pre + post for pre, post in bg]
 
@@ -570,7 +570,7 @@ class Coqtail(object):
         return lines, highlights
 
     def set_goal(self, msg=None, clear=False):
-        # type: (Optional[Tuple[List[Text], List[Tuple[int, int, int, str]]]], bool) -> None
+        # type: (Optional[Tuple[List[Text], List[Tuple[int, int, int, Text]]]], bool) -> None
         """Update the goal message."""
         if msg is not None:
             self.goal_msg, self.goal_hls = msg
@@ -619,11 +619,11 @@ class Coqtail(object):
         return matches
 
     def panels(self, goals=True):
-        # type: (bool) -> Mapping[str, Tuple[List[Text], List[Tuple[int, int, int, str]]]]
+        # type: (bool) -> Mapping[str, Tuple[List[Text], List[Tuple[int, int, int, Text]]]]
         """The auxiliary panel content."""
         panels = {
             "info": (self.info_msg, [])
-        }  # type: Dict[str, Tuple[List[Text], List[Tuple[int, int, int, str]]]]
+        }  # type: Dict[str, Tuple[List[Text], List[Tuple[int, int, int, Text]]]]
         if goals:
             panels["goal"] = (self.goal_msg, self.goal_hls)
         return panels

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -71,11 +71,12 @@ def lines_and_highlights(tagged_tokens, line_no):
                 line_no += 1
                 line, index = '', 1
 
+            tok_len = len(tok.encode('utf-8'))
             if tag is not None:
-                highlights.append((line_no, index, len(tok), tag))
+                highlights.append((line_no, index, tok_len, tag))
 
             line += tok
-            index += len(tok)
+            index += tok_len
 
     lines.append(line)
     return lines, highlights

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -65,7 +65,9 @@ def lines_and_highlights(tagged_tokens, line_no):
     line, index = u"", 1
 
     for token, tag in tagged_tokens:
-        for i, tok in enumerate(token.splitlines()):
+        # NOTE: Can't use splitlines or else tokens like ' =\n' won't properly
+        # begin a new line
+        for i, tok in enumerate(token.split("\n")):
             if i > 0:
                 # Encountered a newline in token
                 lines.append(line)

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -54,16 +54,13 @@ def lines_and_highlights(tagged_tokens, line_no):
     Note that matchaddpos()'s highlight positions are 1-indexed,
     but this function expects line_no to be 0-indexed.
     """
-
     # If tagged_tokens turns out to already be a string (which is the case for
     # older versions of Coq), just return it as is, with no highlights.
     if isinstance(tagged_tokens, string_types):
         return tagged_tokens.splitlines(), []
 
-    lines, highlights = (
-        [],
-        [],
-    )  # type: Tuple[List[Text], List[Tuple[int, int, int, str]]]
+    lines = []  # type: List[Text]
+    highlights = []  # type: List[Tuple[int, int, int, str]]
     line_no += 1  # Convert to 1-indexed per matchaddpos()'s spec
     line, index = "", 1
 
@@ -505,10 +502,8 @@ class Coqtail(object):
     def pp_goals(self, goals, opts):
         # type: (Tuple[List[Any], List[Any], List[Any], List[Any]], Mapping[str, Any]) -> Tuple[List[Text], List[Tuple[int, int, int, str]]]
         """Pretty print the goals."""
-        lines, highlights = (
-            [],
-            [],
-        )  # type: Tuple[List[Text], List[Tuple[int, int, int, str]]]
+        lines = []  # type: List[Text]
+        highlights = []  # type: List[Tuple[int, int, int, str]]
         fg, bg, shelved, given_up = goals
         bg_joined = [pre + post for pre, post in bg]
 
@@ -567,7 +562,6 @@ class Coqtail(object):
                 ls, hls = lines_and_highlights(next_goal.ccl, len(lines))
                 lines += ls
                 highlights += hls
-
             else:
                 lines.append("All goals completed.")
 

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -214,7 +214,7 @@ class Coqtail(object):
 
         failed_at, err = self.send_until_fail(buffer, opts=opts)
         if unmatched is not None and failed_at is None:
-            # Only report unmatched if no other errors occured first
+            # Only report unmatched if no other errors occurred first
             self.set_info(str(unmatched), reset=False)
             self.error_at = unmatched.range
             self.refresh(goals=False, opts=opts)
@@ -273,7 +273,7 @@ class Coqtail(object):
 
             failed_at, err = self.send_until_fail(buffer, opts=opts)
             if unmatched is not None and failed_at is None:
-                # Only report unmatched if no other errors occured first
+                # Only report unmatched if no other errors occurred first
                 self.set_info(str(unmatched), reset=False)
                 self.error_at = unmatched.range
                 self.refresh(goals=False, opts=opts)

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -285,12 +285,13 @@ class Coqtail(object):
         """Rewind to the beginning of the file."""
         return self.rewind_to(0, 1, opts=opts)
 
-    def query(self, args, opts):
-        # type: (List[Text], Mapping[str, Any]) -> None
+    def query(self, args, opts, silent=False):
+        # type: (List[Text], Mapping[str, Any], bool) -> None
         """Forward Coq query to Coqtop interface."""
-        _, msg, stderr = self.do_query(" ".join(args), opts=opts)
+        success, msg, stderr = self.do_query(" ".join(args), opts=opts)
 
-        self.set_info(msg, reset=True)
+        if not success or not silent:
+            self.set_info(msg, reset=True)
         self.print_stderr(stderr)
         self.refresh(goals=False, opts=opts)
 

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -1329,9 +1329,9 @@ class XMLInterface86(XMLInterface85):
         self._to_py_funcs.update({"richpp": self._to_richpp})
 
     def _to_richpp(self, xml):
-        # type: (ET.Element) -> Iterable[Tuple[Text,Optional[str]]]
+        # type: (ET.Element) -> List[Tuple[Text,Optional[str]]]
         """Expect: <richpp>richpp</richpp>"""
-        return parse_tagged_tokens(self.richpp_tags, xml)
+        return list(parse_tagged_tokens(self.richpp_tags, xml))
 
     # XML Parsing and Marshalling #
     # Overrides _to_message() from 8.5

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -360,7 +360,7 @@ class XMLInterfaceBase(object):
         """Expect: <string>str</string>"""
         # In Python 2 itertext returns Generator[Any, None, None] instead
         # of Generator[str, None, None]
-        return "".join(xml.itertext())  # type: ignore[no-any-return]
+        return u"".join(xml.itertext())  # type: ignore[no-any-return]
 
     def _of_string(self, val):
         # type: (Text) -> ET.Element

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -532,7 +532,7 @@ class XMLInterfaceBase(object):
                 # _to_py is guaranteed to either return Text or
                 # a sequence of tagged tokens for message or feedback
                 msg = self._to_py(xml)
-                if not isinstance(msg, Text):
+                if not isinstance(msg, str):
                     msg = join_tagged_tokens(msg) # type: ignore
 
                 msgs.append(msg.strip())

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -114,13 +114,13 @@ def _parse_tagged_tokens(tags, xml, stack, inner):
 
     # Check tag, see if we should modify stack
     if xml.tag.startswith("start."):
-        _, _, tag = xml.tag.rpartition("start.") # assert(tag != "")
+        _, _, tag = xml.tag.rpartition("start.")  # assert(tag != "")
         if tag in tags:
             # start. tag: push onto stack
             stack.insert(0, tag)
 
     elif xml.tag.startswith("end."):
-        _, _, tag = xml.tag.rpartition("end.") # assert(tag != "")
+        _, _, tag = xml.tag.rpartition("end.")  # assert(tag != "")
         if tag in tags:
             # end. tag: remove from stack (even if it's not at the top)
             pop_after = tag
@@ -181,7 +181,7 @@ def join_tagged_tokens(tagged_tokens):
         forall xml tags,
             join_tagged_tokens(parse_tagged_token(tags, xml)) = "".join(xml.itertext())
     """
-    return ''.join([s for (s, _) in tagged_tokens])
+    return "".join([s for (s, _) in tagged_tokens])
 
 
 # Debugging #
@@ -535,7 +535,9 @@ class XMLInterfaceBase(object):
                 if isinstance(msg, list):
                     msg = join_tagged_tokens(msg)
 
-                assert isinstance(msg, string_types), unexpected(string_types, type(msg))
+                assert isinstance(msg, string_types), unexpected(
+                    string_types, type(msg)
+                )
 
                 msgs.append(msg.strip())
             else:
@@ -1310,11 +1312,11 @@ class XMLInterface86(XMLInterface85):
 
     # Tags to look for when parsing richpp
     richpp_tags = [
-                "diff.added",
-                "diff.removed",
-                "diff.added.bg",
-                "diff.removed.bg",
-                ]
+        "diff.added",
+        "diff.removed",
+        "diff.added.bg",
+        "diff.removed.bg",
+    ]
 
     def __init__(self, versions):
         # type: (Tuple[int, ...]) -> None

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -532,7 +532,7 @@ class XMLInterfaceBase(object):
                 # _to_py is guaranteed to either return Text or
                 # a sequence of tagged tokens for message or feedback
                 msg = self._to_py(xml)
-                if not isinstance(msg, str):
+                if not isinstance(msg, str) or isinstance(msg, list):
                     msg = join_tagged_tokens(msg) # type: ignore
 
                 msgs.append(msg.strip())

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -532,10 +532,10 @@ class XMLInterfaceBase(object):
                 # _to_py is guaranteed to either return Text or
                 # a sequence of tagged tokens for message or feedback
                 msg = self._to_py(xml)
-                if not isinstance(msg, str):
-                    msg = join_tagged_tokens(msg) # type: ignore
+                if isinstance(msg, list):
+                    msg = join_tagged_tokens(msg)
 
-                msgs.append(msg.strip())
+                msgs.append(msg.strip()) # type: ignore
             else:
                 raise unexpected(("value", "message", "feedback"), xml.tag)
 

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -535,7 +535,9 @@ class XMLInterfaceBase(object):
                 if isinstance(msg, list):
                     msg = join_tagged_tokens(msg)
 
-                msgs.append(msg.strip()) # type: ignore
+                assert isinstance(msg, string_types), unexpected(string_types, type(msg))
+
+                msgs.append(msg.strip())
             else:
                 raise unexpected(("value", "message", "feedback"), xml.tag)
 

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -532,7 +532,7 @@ class XMLInterfaceBase(object):
                 # _to_py is guaranteed to either return Text or
                 # a sequence of tagged tokens for message or feedback
                 msg = self._to_py(xml)
-                if not isinstance(msg, str) or isinstance(msg, list):
+                if not isinstance(msg, str):
                     msg = join_tagged_tokens(msg) # type: ignore
 
                 msgs.append(msg.strip())

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -132,7 +132,7 @@ def _parse_tagged_tokens(tags, xml, stack, inner):
 
     # Get text before first inner child
     if xml.text is not None:
-        yield (xml.text, stack.copy())
+        yield (xml.text, stack[:])
 
     # Recurse on children, with modified stack
     for child in xml:
@@ -144,7 +144,7 @@ def _parse_tagged_tokens(tags, xml, stack, inner):
 
     # Get trailing text up to start of next tag, unless this is the outermost tag
     if inner and xml.tail is not None:
-        yield (xml.tail, stack.copy())
+        yield (xml.tail, stack[:])
 
 
 def parse_tagged_tokens(tags, xml):

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     from distutils.spawn import find_executable as which  # type: ignore[no-redef]
 
-from six import add_metaclass, string_types
+from six import add_metaclass, string_types, text_type
 
 # For Mypy
 # TODO: Replace some of the 'Any's with more specific types. But in order
@@ -93,7 +93,7 @@ def _unescape(cmd):
 
 
 def _parse_tagged_tokens(tags, xml, stack=None, inner=False):
-    # type: (List[Text], ET.Element, Optional[List[Text]], bool) -> Iterable[Tuple[Text, List[Text]]]
+    # type: (Sequence[str], ET.Element, Optional[List[Text]], bool) -> Iterable[Tuple[Text, List[Text]]]
     """Scrape an XML element into a stream of text tokens and stack of tags.
 
     Helper function to parse_tagged_tokens.
@@ -149,13 +149,13 @@ def _parse_tagged_tokens(tags, xml, stack=None, inner=False):
 
 
 def parse_tagged_tokens(tags, xml):
-    # type: (List[Text], ET.Element) -> Iterable[Tuple[Text, Optional[Text]]]
+    # type: (Sequence[str], ET.Element) -> Iterable[Tuple[Text, Optional[Text]]]
     """Scrape an XML element into a stream of text tokens and accompanying tags.
 
     Written to support richpp markup.
     Only considers tags specified by the tags parameter.
     """
-    token_acc, last_tag = "", None
+    token_acc, last_tag = u"", None
 
     # Recursive helper _parse_tagged_tokens gives us tag stacks
     for token, tag_list in _parse_tagged_tokens(tags, xml):
@@ -535,8 +535,8 @@ class XMLInterfaceBase(object):
                     msg = join_tagged_tokens(msg)
 
                 # Sanity check
-                if not isinstance(msg, string_types):
-                    raise unexpected(string_types, type(msg))
+                if not isinstance(msg, text_type):
+                    raise unexpected((text_type,), type(msg))
 
                 msgs.append(msg.strip())
             else:
@@ -783,7 +783,7 @@ class XMLInterface84(XMLInterfaceBase):
             return self._to_py(content[1])  # type: ignore[return-value]
         else:
             # TODO: maybe make use of this info?
-            return ""
+            return u""
 
     # Coqtop Commands #
     def init(self, _encoding="utf-8"):
@@ -1130,7 +1130,7 @@ class XMLInterface85(XMLInterfaceBase):
             return self._to_py(content[1])  # type: ignore[return-value]
         else:
             # TODO: maybe make use of this info?
-            return ""
+            return u""
 
     # Coqtop Commands #
     def init(self, encoding="utf-8"):
@@ -1332,7 +1332,7 @@ class XMLInterface86(XMLInterface85):
         self._to_py_funcs.update({"richpp": self._to_richpp})
 
     def _to_richpp(self, xml):
-        # type: (ET.Element) -> List[Tuple[Text, Optional[str]]]
+        # type: (ET.Element) -> List[Tuple[Text, Optional[Text]]]
         """Expect: <richpp>richpp</richpp>"""
         return list(parse_tagged_tokens(self.richpp_tags, xml))
 
@@ -1359,7 +1359,7 @@ class XMLInterface86(XMLInterface85):
             return self._to_py(content[0])  # type: ignore[return-value]
         else:
             # TODO: maybe make use of this info?
-            return ""
+            return u""
 
 
 class XMLInterface87(XMLInterface86):

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -27,7 +27,6 @@ from six import add_metaclass, string_types
 # requirement need to define dummy replacements for some of the below
 try:
     from typing import (
-        cast,
         Any,
         Callable,
         Dict,
@@ -40,14 +39,7 @@ try:
         Union,
     )
 except ImportError:
-    def cast(_, o): # type: ignore
-        """Mimics mypy's cast() function; does nothing and returns second arg
-
-        For some reason, cast() needs to appear as a function rather than
-        as a comment like all other Mypy type hints. So if we don't have typing,
-        we just mock out this function.
-        """
-        return o
+    pass
 
 
 class FindCoqtopError(Exception):
@@ -539,11 +531,9 @@ class XMLInterfaceBase(object):
             elif xml.tag in ("message", "feedback"):
                 # _to_py is guaranteed to either return Text or
                 # a sequence of tagged tokens for message or feedback
-                msg = cast(Union[Text, Iterable[Tuple[str, Optional[str]]]],
-                        self._to_py(xml))
-
+                msg = self._to_py(xml)
                 if not isinstance(msg, Text):
-                    msg = join_tagged_tokens(msg)
+                    msg = join_tagged_tokens(msg) # type: ignore
 
                 msgs.append(msg.strip())
             else:

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -40,9 +40,9 @@ if !exists('b:coqtail_did_highlight') || !b:coqtail_did_highlight
       hi def CoqtailSent ctermbg=7 guibg=LimeGreen
     endif
     hi def link CoqtailDiffAdded DiffText
-    hi def link CoqtailDiffRemoved DiffDelete
     hi def link CoqtailDiffAddedBg DiffChange
-    hi def link CoqtailDiffRemovedBg DiffChange
+    hi def link CoqtailDiffRemoved DiffDelete
+    hi def link CoqtailDiffRemovedBg DiffDelete
     hi def link CoqtailError Error
   endfunction
 

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -39,6 +39,11 @@ if !exists('b:coqtail_did_highlight') || !b:coqtail_did_highlight
       hi def CoqtailChecked ctermbg=4 guibg=LightGreen
       hi def CoqtailSent ctermbg=7 guibg=LimeGreen
     endif
+    " TODO: check these with someone...
+    hi def CoqtailDiffAddedBg ctermbg=0 guibg=Black
+    hi def CoqtailDiffRemovedBg ctermbg=0 guibg=Black
+    hi def CoqtailDiffAdded ctermbg=2 guibg=Green
+    hi def CoqtailDiffRemoved ctermbg=1 guibg=Red
     hi def link CoqtailError Error
   endfunction
 

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -39,11 +39,10 @@ if !exists('b:coqtail_did_highlight') || !b:coqtail_did_highlight
       hi def CoqtailChecked ctermbg=4 guibg=LightGreen
       hi def CoqtailSent ctermbg=7 guibg=LimeGreen
     endif
-    " TODO: check these with someone...
-    hi def CoqtailDiffAddedBg ctermbg=0 guibg=Black
-    hi def CoqtailDiffRemovedBg ctermbg=0 guibg=Black
-    hi def CoqtailDiffAdded ctermbg=2 guibg=Green
-    hi def CoqtailDiffRemoved ctermbg=1 guibg=Red
+    hi def link CoqtailDiffAdded DiffText
+    hi def link CoqtailDiffRemoved DiffDelete
+    hi def link CoqtailDiffAddedBg DiffChange
+    hi def link CoqtailDiffRemovedBg DiffChange
     hi def link CoqtailError Error
   endfunction
 

--- a/tests/unit/test_xmlInterface.py
+++ b/tests/unit/test_xmlInterface.py
@@ -73,7 +73,7 @@ class ToOfTests(object):
 
     def abc_richpp(self):
         if self.xi.versions >= (8, 6, 0):
-            return PyXML(self.abc().py, mkXML("richpp", text="abc"), True)
+            return PyXML([("abc", None)], mkXML("richpp", text="abc"), False)
         return None
 
     def list1(self):
@@ -353,9 +353,7 @@ def test_to_of_py(xmlInt, py_xml):
 
     assert xmlInt._to_py(xml) == py
     if py_xml.bijection:
-        assert tostring(xmlInt._of_py(py)) == tostring(xml).replace(
-            b"richpp", b"string"
-        )
+        assert tostring(xmlInt._of_py(py)) == tostring(xml)
 
 
 def test_valid_module(xmlInt):


### PR DESCRIPTION
Adds proof diffs to Coqtail (#57).

Summary of changes on Python side:
- Replace the `_to_string()` function with `_to_richpp()`, which gives a list of tagged tokens for Coq 8.6+
- Maintain addition `goal_hls` state to keep track of all the highlights to be applied to the goal panel
- `pp_goals()` now builds and returns a list of lines and highlights (it was previously returning a single text string, which was later being `.split(\n)` prior to be being set to `goal_msg`)
- Send both lines and highlights to Vim side (send empty list of highlights for the info panel)

Summary of changes on Vim side:
- Added some new highlight groups for diffs
- Add buffer state to keep track of highlighted ranges
- Receive additional `richpp` information from Python side
- Use `richpp` to highlight proof diffs

Remaining items:
- [x] Test on Vim, Gvim, Neovim, etc.
- [x] Test with different Coq versions
- [x] Preserve newlines in `line_and_highlights()` function
- [x] Better default highlight colors
- [x] ~Support turning diffs on and off from Coqtail (rather than having to use `Set Diffs "on".`)~ (Turns out `:Coq Set Diffs "on"` is already supported)