### PR TITLE
make CoqJumpToEnd a jump command

### DIFF
--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -445,6 +445,7 @@ function! coqtail#jumptoend() abort
 
   let [l:ok, l:pos] = s:call('endpoint', 'sync', 0, {})
   if l:ok
+    mark '
     call cursor(l:pos)
   endif
 endfunction


### PR DESCRIPTION
This makes it possible to jump back to the position before running CoqJumpToEnd