### PR TITLE
bwipeout aux panels

### DIFF
--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -274,7 +274,7 @@ endfunction
 " Delete panel variables and clear highlighting.
 function! coqtail#panels#cleanup() abort
   for l:panel in g:coqtail#panels#aux
-    silent! execute 'bdelete' . b:coqtail_panel_bufs[l:panel]
+    silent! execute 'bwipeout' b:coqtail_panel_bufs[l:panel]
   endfor
   silent! unlet b:coqtail_panel_bufs
 


### PR DESCRIPTION
Auxiliary buffers are never accessed after cleanup, so use `bwipeout` instead of `bdelete`.