### PR TITLE
use bytes for everyting related to vim buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   (PR #148)
 
 ### Fixed
+- Correctly handle highlighting of multibyte characters (for real this time). (PR #177)
 - Preserve jumplist and alternate file when opening Info and Goal panels. (PR #150)
 - Don't list Info and Goal panel buffers. (PR #151)
 - Catch exception in `CoqtailServer` when the connection is reset by the peer.

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -13,6 +13,7 @@ from collections import defaultdict as ddict
 from collections import deque
 from itertools import islice
 
+from six import indexbytes, iterbytes
 from six.moves import zip_longest
 from six.moves.queue import Empty, Queue
 from six.moves.socketserver import StreamRequestHandler, ThreadingTCPServer
@@ -1096,20 +1097,20 @@ def _find_next_sentence(lines, sline, scol):
             break
 
     # Check if the first character of the sentence is a bullet
-    if first_line[0] in bullets:
+    if indexbytes(first_line, 0) in bullets:
         # '-', '+', '*' can be repeated
-        for c in first_line[1:]:
-            if c in bullets[2:] and c == first_line[0]:
+        for c in iterbytes(first_line[1:]):
+            if c in bullets[2:] and c == indexbytes(first_line, 0):
                 col += 1
             else:
                 break
         return (line, col)
 
     # Check if this is a bracketed goal selector
-    if _char_isdigit(first_line[0]):
+    if _char_isdigit(indexbytes(first_line, 0)):
         state = "digit"
         selcol = col
-        for c in first_line[1:]:
+        for c in iterbytes(first_line[1:]):
             if state == "digit" and _char_isdigit(c):
                 selcol += 1
             elif state == "digit" and _char_isspace(c):
@@ -1350,4 +1351,4 @@ def _char_isdigit(c):
 
 def _char_isspace(c):
     # type: (int) -> bool
-    return c in b" \t\n\r\x0b\f"
+    return c in iterbytes(b" \t\n\r\x0b\f")

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -20,6 +20,7 @@ from six.moves.socketserver import StreamRequestHandler, ThreadingTCPServer
 import coqtop as CT
 
 # For Mypy
+# mypy: strict-equality
 try:
     from typing import (
         Any,
@@ -1069,7 +1070,7 @@ def _get_message_range(lines, after):
 def _find_next_sentence(lines, sline, scol):
     # type: (Sequence[bytes], int, int) -> Tuple[int, int]
     """Find the next sentence to send to Coq."""
-    bullets = (b"{", b"}", b"-", b"+", b"*")
+    bullets = (ord("{"), ord("}"), ord("-"), ord("+"), ord("*"))
 
     line, col = (sline, scol)
     while True:
@@ -1114,17 +1115,17 @@ def _find_next_sentence(lines, sline, scol):
             elif state == "digit" and _char_isspace(c):
                 state = "beforecolon"
                 selcol += 1
-            elif state == "digit" and c == b":":
+            elif state == "digit" and c == ord(":"):
                 state = "aftercolon"
                 selcol += 1
             elif state == "beforecolon" and _char_isspace(c):
                 selcol += 1
-            elif state == "beforecolon" and c == b":":
+            elif state == "beforecolon" and c == ord(":"):
                 state = "aftercolon"
                 selcol += 1
             elif state == "aftercolon" and _char_isspace(c):
                 selcol += 1
-            elif state == "aftercolon" and c == b"{":
+            elif state == "aftercolon" and c == ord("{"):
                 selcol += 1
                 return (line, selcol)
             else:
@@ -1309,7 +1310,7 @@ def _strip_comments(msg):
     off = 0
     nesting = 0
 
-    while msg != "":
+    while msg != b"":
         start = msg.find(b"(*")
         end = msg.find(b"*)")
         if start == -1 and (end == -1 or (end != -1 and nesting == 0)):

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -658,8 +658,14 @@ class Coqtail(object):
     def buffer(self):
         # type: () -> Sequence[bytes]
         """The contents of this buffer."""
-        lines = self.handler.vimcall("getbufline", True, self.handler.bnum, 1, "$")  # type: Sequence[Text]
-        return list(map(lambda l: l.encode("utf-8"), lines))
+        lines = self.handler.vimcall(
+            "getbufline",
+            True,
+            self.handler.bnum,
+            1,
+            "$",
+        )  # type: Sequence[Text]
+        return [line.encode("utf-8") for line in lines]
 
 
 class CoqtailHandler(StreamRequestHandler):
@@ -1345,9 +1351,11 @@ def _find_diff(x, y, stop=None):
         seq = islice(seq, stop)
     return next((i for i, vs in seq if vs[0] != vs[1]), None)
 
+
 def _char_isdigit(c):
     # type: (int) -> bool
-    return 48 <= c <= 57
+    return ord("0") <= c <= ord("9")
+
 
 def _char_isspace(c):
     # type: (int) -> bool

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -21,7 +21,6 @@ from six.moves.socketserver import StreamRequestHandler, ThreadingTCPServer
 import coqtop as CT
 
 # For Mypy
-# mypy: strict-equality
 try:
     from typing import (
         Any,
@@ -1103,20 +1102,22 @@ def _find_next_sentence(lines, sline, scol):
             break
 
     # Check if the first character of the sentence is a bullet
-    if indexbytes(first_line, 0) in bullets:
+    if indexbytes(first_line, 0) in bullets:  # type: ignore[no-untyped-call]
         # '-', '+', '*' can be repeated
         for c in iterbytes(first_line[1:]):
-            if c in bullets[2:] and c == indexbytes(first_line, 0):
+            if c in bullets[2:] and c == indexbytes(first_line, 0):  # type: ignore[no-untyped-call]
                 col += 1
             else:
                 break
         return (line, col)
 
     # Check if this is a bracketed goal selector
-    if _char_isdigit(indexbytes(first_line, 0)):
+    if _char_isdigit(indexbytes(first_line, 0)):  # type: ignore[no-untyped-call]
         state = "digit"
         selcol = col
         for c in iterbytes(first_line[1:]):
+            # Hack to silence mypy complaints in Python 2
+            assert isinstance(c, int)
             if state == "digit" and _char_isdigit(c):
                 selcol += 1
             elif state == "digit" and _char_isspace(c):
@@ -1359,4 +1360,4 @@ def _char_isdigit(c):
 
 def _char_isspace(c):
     # type: (int) -> bool
-    return c in iterbytes(b" \t\n\r\x0b\f")
+    return c in iterbytes(b" \t\n\r\x0b\f")  # type: ignore[operator]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ disallow_incomplete_defs = True
 check_untyped_defs = True
 disallow_untyped_decorators = True
 no_implicit_optional = True
+strict_equality = True
 warn_redundant_casts = True
 warn_unused_ignores = True
 warn_return_any = True

--- a/tests/unit/test_matcher.py
+++ b/tests/unit/test_matcher.py
@@ -9,16 +9,16 @@ import pytest
 from coqtail import matcher
 
 tests = (
-    ("Both lines, both cols", matcher[1:5, 1:5], r"\%2l\%>1v\|\%>2l\%<5l\|\%5l\%<6v"),
-    ("Both lines, 1 start col", matcher[1:5, 0:5], r"\%2l\|\%>2l\%<5l\|\%5l\%<6v"),
-    ("Both lines, no start col", matcher[1:5, :5], r"\%2l\|\%>2l\%<5l\|\%5l\%<6v"),
-    ("Both lines, no end col", matcher[1:5, 1:], r"\%2l\%>1v\|\%>2l\%<5l\|\%5l"),
+    ("Both lines, both cols", matcher[1:5, 1:5], r"\%2l\%>1c\|\%>2l\%<5l\|\%5l\%<6c"),
+    ("Both lines, 1 start col", matcher[1:5, 0:5], r"\%2l\|\%>2l\%<5l\|\%5l\%<6c"),
+    ("Both lines, no start col", matcher[1:5, :5], r"\%2l\|\%>2l\%<5l\|\%5l\%<6c"),
+    ("Both lines, no end col", matcher[1:5, 1:], r"\%2l\%>1c\|\%>2l\%<5l\|\%5l"),
     ("Both lines, no col", matcher[1:5, :], r"\%2l\|\%>2l\%<5l\|\%5l"),
-    ("0 start line, both cols", matcher[0:5, 1:5], r"\%1l\%>1v\|\%>1l\%<5l\|\%5l\%<6v"),
-    ("No start line, both cols", matcher[:5, 1:5], r"\%1l\%>1v\|\%>1l\%<5l\|\%5l\%<6v"),
-    ("One line, both cols", matcher[1:2, 1:5], r"\%2l\%>1v\%<6v"),
+    ("0 start line, both cols", matcher[0:5, 1:5], r"\%1l\%>1c\|\%>1l\%<5l\|\%5l\%<6c"),
+    ("No start line, both cols", matcher[:5, 1:5], r"\%1l\%>1c\|\%>1l\%<5l\|\%5l\%<6c"),
+    ("One line, both cols", matcher[1:2, 1:5], r"\%2l\%>1c\%<6c"),
     ("One line, no col", matcher[1:2, :], r"\%2l"),
-    ("Two lines, both cols", matcher[1:3, 1:5], r"\%2l\%>1v\|\%3l\%<6v"),
+    ("Two lines, both cols", matcher[1:3, 1:5], r"\%2l\%>1c\|\%3l\%<6c"),
 )
 
 

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -74,7 +74,12 @@ tests = (
 
 # Default 'start' to (0, 0)
 tests = (
-    (t[0], list(map(lambda s: s.encode("utf-8"), t[1])), t[2] if len(t) == 4 else (0, 0), t[3] if len(t) == 4 else t[2])
+    (
+        t[0],
+        list(map(lambda s: s.encode("utf-8"), t[1])),
+        t[2] if len(t) == 4 else (0, 0),
+        t[3] if len(t) == 4 else t[2],
+    )
     for t in tests
 )
 
@@ -94,37 +99,32 @@ def test_parse(_name, lines, start, stop):
 
 
 com_tests = (
-    ("no comment", "abc", ("abc", [])),
-    ("pre", "(*abc*)def", (" def", [[0, 7]])),
-    ("mid", "ab(* c *)de", ("ab de", [[2, 7]])),
-    ("post", "abc(*def *)", ("abc", [[3, 8]])),
+    ("no comment", b"abc", (b"abc", [])),
+    ("pre", b"(*abc*)def", (b" def", [[0, 7]])),
+    ("mid", b"ab(* c *)de", (b"ab de", [[2, 7]])),
+    ("post", b"abc(*def *)", (b"abc", [[3, 8]])),
     (
         "multi",
-        "abc (* com1 *)  def (*com2 *) g",
-        ("abc    def   g", [[4, 10], [20, 9]]),
+        b"abc (* com1 *)  def (*com2 *) g",
+        (b"abc    def   g", [[4, 10], [20, 9]]),
     ),
-    ("nested", "abc (* c1 (*c2 (*c3*) (*c4*) *) *)def", ("abc  def", [[4, 30]])),
-    ("no comment newline", "\nabc\n\n", ("\nabc\n\n", [])),
-    ("pre newline", "(*ab\nc*)d\nef", (" d\nef", [[0, 8]])),
-    ("mid newline", "ab(* c *)\nde", ("ab \nde", [[2, 7]])),
-    ("post newline", "abc\n(*def *)\n", ("abc\n \n", [[4, 8]])),
+    ("nested", b"abc (* c1 (*c2 (*c3*) (*c4*) *) *)def", (b"abc  def", [[4, 30]])),
+    ("no comment newline", b"\nabc\n\n", (b"\nabc\n\n", [])),
+    ("pre newline", b"(*ab\nc*)d\nef", (b" d\nef", [[0, 8]])),
+    ("mid newline", b"ab(* c *)\nde", (b"ab \nde", [[2, 7]])),
+    ("post newline", b"abc\n(*def *)\n", (b"abc\n \n", [[4, 8]])),
     (
         "multi newline",
-        "abc (* com1 *)\n def \n(*\ncom2 *) g",
-        ("abc  \n def \n  g", [[4, 10], [21, 10]]),
+        b"abc (* com1 *)\n def \n(*\ncom2 *) g",
+        (b"abc  \n def \n  g", [[4, 10], [21, 10]]),
     ),
     (
         "nested newline",
-        "\nabc (* c1 (*c2 \n\n(*c3\n*) (*c4*) *) *)def\n",
-        ("\nabc  def\n", [[5, 33]]),
+        b"\nabc (* c1 (*c2 \n\n(*c3\n*) (*c4*) *) *)def\n",
+        (b"\nabc  def\n", [[5, 33]]),
     ),
-    ("star paren", "abc *)", ("abc *)", [])),
-    ("star paren post comment", "(*abc*) *)", ("  *)", [[0, 7]])),
-)
-
-com_tests = (
-    (t[0], t[1].encode("utf-8"), (t[2][0].encode("utf-8"), t[2][1]))
-    for t in com_tests
+    ("star paren", b"abc *)", (b"abc *)", [])),
+    ("star paren post comment", b"(*abc*) *)", (b"  *)", [[0, 7]])),
 )
 
 

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -74,7 +74,7 @@ tests = (
 
 # Default 'start' to (0, 0)
 tests = (
-    (t[0], t[1], t[2] if len(t) == 4 else (0, 0), t[3] if len(t) == 4 else t[2])
+    (t[0], list(map(lambda s: s.encode("utf-8"), t[1])), t[2] if len(t) == 4 else (0, 0), t[3] if len(t) == 4 else t[2])
     for t in tests
 )
 
@@ -120,6 +120,11 @@ com_tests = (
     ),
     ("star paren", "abc *)", ("abc *)", [])),
     ("star paren post comment", "(*abc*) *)", ("  *)", [[0, 7]])),
+)
+
+com_tests = (
+    (t[0], t[1].encode("utf-8"), (t[2][0].encode("utf-8"), t[2][1]))
+    for t in com_tests
 )
 
 


### PR DESCRIPTION
fixes #170

Note: From python >= 3.6, `json.loads()` can take `bytes`.
(https://docs.python.org/3/library/json.html#json.loads)