### PR TITLE
stay in visual mode when refreshing

### DIFF
--- a/autoload/coqtail/compat.vim
+++ b/autoload/coqtail/compat.vim
@@ -7,6 +7,17 @@ let g:coqtail#compat#t_list = type([])
 let g:coqtail#compat#nvim = has('nvim')
 let g:coqtail#compat#has_channel = (has('channel') && has('patch-8.0.0001')) || g:coqtail#compat#nvim
 
+" Use `deletebufline` when available because `:delete` forces vim to exit visual mode.
+if exists('*deletebufline')
+  function! coqtail#compat#deleteline(first, last) abort
+    call deletebufline('%', a:first, a:last)
+  endfunction
+else
+  function! coqtail#compat#deleteline(first, last) abort
+    execute 'silent' a:first ',' a:last 'delete _'
+  endfunction
+endif
+
 " Python compatibility.
 if has('python3')
   command! -nargs=1 Py py3 <args>

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -235,7 +235,7 @@ function! s:replace(buf, panel, txt, richpp, scroll) abort
   endfor
 
   " Update buffer text
-  silent %delete _
+  call coqtail#compat#deleteline(1, '$')
   call append(0, a:txt)
 
   " Set new highlights


### PR DESCRIPTION
Using `deletebufline` instead of `:delete` prevents vim/neovim from exiting visual mode (not sure why).
But this works only when all the windows being refreshed are in the current tab page.

Partially fixes #197.