### PR TITLE
Detect when coqtop crashes on start instead of hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased ([master])
 
 ### Fixed
+- Detect when Coqtop crashes on `:CoqStart` and print the error message instead
+  of hanging.
+  (PR #205)
 - Work around a NeoVim bug with `py3eval` that caused Coqtail to incorrectly
   detect a lack of Python 3 support.
   (PR #204)

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -11,7 +11,7 @@ let s:python_dir = expand('<sfile>:p:h:h') . '/python'
 let g:coqtail#supported = coqtail#compat#init(s:python_dir)
 if !g:coqtail#supported
   call coqtail#util#warn(
-    \ 'Coqtail requires Python 3.6 or later. ' .
+    \ "Coqtail requires Python 3.6 or later.\n" .
     \ 'See https://github.com/whonore/Coqtail/blob/master/README.md#python-2-support.'
   \)
   finish
@@ -45,7 +45,7 @@ let s:default_coqs = [
 let s:goal_lines = 5
 " Warning/error messages.
 let s:unsupported_msg =
-  \ 'Coqtail does not officially support your version of Coq (%s). ' .
+  \ "Coqtail does not officially support your version of Coq (%s).\n" .
   \ 'Continuing with the interface for the latest supported version (' .
   \ s:supported[-1] . ').'
 " Server port.
@@ -375,8 +375,8 @@ function! coqtail#start(...) abort
     if !l:supported
       if b:coqtail_version == -1
         call coqtail#util#err(printf(
-          \ 'No %s binary found. Check that it exists in your $PATH, or set ' .
-          \ 'b:coqtail_coq_path.',
+          \ "No %s binary found.\n" .
+          \ 'Check that it exists in your $PATH, or set b:coqtail_coq_path.',
           \ coqtail#util#getvar([b:, g:], 'coqtail_coq_prog', 'coqtop')))
         call coqtail#stop()
         return 0

--- a/autoload/coqtail/util.vim
+++ b/autoload/coqtail/util.vim
@@ -1,17 +1,26 @@
 " Author: Wolf Honore
 " Utility functions.
 
-" Print a message with warning highlighting.
+" Print a message with the specified highlighting.
 " NOTE: Without 'unsilent' messages triggered during autocmds don't display in
 " NeoVim because 'shortmess+=F' is set by default.
 " See: https://github.com/neovim/neovim/issues/8675
+function! s:echom(msg, hl) abort
+  execute 'echohl' a:hl
+  for l:line in split(a:msg, '\n')
+    unsilent echom l:line
+  endfor
+  echohl None
+endfunction
+
+" Print a message with warning highlighting.
 function! coqtail#util#warn(msg) abort
-  echohl WarningMsg | unsilent echom a:msg | echohl None
+  call s:echom(a:msg, 'WarningMsg')
 endfunction
 
 " Print a message with error highlighting.
 function! coqtail#util#err(msg) abort
-  echohl ErrorMsg | unsilent echom a:msg | echohl None
+  call s:echom(a:msg, 'ErrorMsg')
 endfunction
 
 " Get the word under the cursor using the special '<cword>' variable. First

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -204,7 +204,7 @@ class Coqtail:
             errmsg.append(str(e))
 
         if errmsg != []:
-            return "Failed to launch Coq. " + ". ".join(errmsg)
+            return "Failed to launch Coq.\n" + "\n".join(errmsg)
         return None
 
     def stop(self, opts: VimOptions) -> None:


### PR DESCRIPTION
Related to #199. Doesn't solve the problem, but at least `:CoqStart` fails quickly and shows the error message from coqtop.