### PR TITLE
Adjust "add" message for Coq 8.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased ([master])
 
 ### Added
+- Preliminary support for Coq 8.15.
+  (PR #209)
 - Support for Coq 8.14.
   (PRs #211, #213, #240)
 

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -1707,7 +1707,7 @@ class XMLInterface814(XMLInterface813):
           verbose: bool - Verbose output
           bp: int - Byte offset of phrase in script
           line_nb: int - Line number of phrase in script
-          bol_pos: int - Byte offset for beginning of line 
+          bol_pos: int - Byte offset for beginning of line
         """
         return (
             "Add",
@@ -1724,7 +1724,6 @@ class XMLInterface814(XMLInterface813):
           res_msg: str - Messages produced by 'Add' (removed in 8.14)
           state_id: int - The new state id
         """
-        # pylint: disable=no-self-use
         if isinstance(res, Ok):
             val: Tuple[XMLInterface85.CoqStateId, Any] = res.val
             res.val = {"res_msg": "", "state_id": val[0].id}

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -1705,14 +1705,16 @@ class XMLInterface814(XMLInterface813):
           edit_id: int - The current edit id ?
           state_id: CoqStateId - The current state id
           verbose: bool - Verbose output
-          off: int - Offset of phrase in script
+          bp: int - Byte offset of phrase in script
+          line_nb: int - Line number of phrase in script
+          bol_pos: int - Byte offset for beginning of line 
         """
         return (
             "Add",
             self._make_call(
                 encoding,
                 "Add",
-                children=(((cmd, -1), (self.CoqStateId(state), True)), 0),
+                children=((((cmd, -1), (self.CoqStateId(state), True)), 0), (0, 0)),
             ),
         )
 

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -1710,6 +1710,30 @@ class XMLInterface814(XMLInterface813):
                 )
         return res
 
+    # todo: how to test this before 8.14 comes out?
+    def add(
+            self,
+            cmd: str,
+            state: int,
+            encoding: str = "utf-8",
+    ) -> Tuple[str, Optional[bytes]]:
+        """Create an XML string to advance Coqtop.
+        Args:
+          cmd: string - The command to evaluate
+          edit_id: int - The current edit id ?
+          state_id: CoqStateId - The current state id
+          verbose: bool - Verbose output
+          off: int - offset of phrase in script
+        """
+        return (
+            "Add",
+            self._make_call(
+                encoding,
+                "Add",
+                children=(((cmd, -1), (self.CoqStateId(state), True)),0),
+            ),
+        )
+
 
 XMLInterfaces = (
     ((8, 4, 0), (8, 5, 0), XMLInterface84),


### PR DESCRIPTION
~I'd like to merge https://github.com/coq/coq/pull/14252 for Coq 8.14.~  That PR modifies the `add` message, so the coqtail tests need to be updated.  The changes update the `add` message to add new values to the sent type and remove an unused value from the return type.  The added values are relevant only for the visual debugger.

I think my code for adding the new parameter is close to correct, but I couldn't find the code that checks for the value in the return type.  Can you tell me what needs to change for that?

~I'd like to get my Coq PR into 8.14, which has a freeze date of May 31.  I hope we can update the tests in the next few days rather than waiting until the last minute.~

Let me know your thoughts, thanks.

The message types change from:
```
type add_sty = (string * edit_id) * (state_id * verbose)
type add_rty = state_id * ((unit, state_id) union * string)
```

to:

```
type add_sty = (((string * edit_id) * (state_id * verbose)) * int) * (int * int)
type add_rty = state_id * (unit, state_id) union
```

Updated 14 Sept 2021  The associated Coq PR is now https://github.com/coq/coq/pull/14644