### PR TITLE
Clear `b:coqtail_panel_richpp` when hiding the Goal or Info panels

### DIFF
--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -351,11 +351,11 @@ function! coqtail#start(...) abort
     endif
 
     " Draw the logo
-    let l:info_win = bufwinnr(b:coqtail_panel_bufs[g:coqtail#panels#info])
+    let l:info_winid = bufwinid(b:coqtail_panel_bufs[g:coqtail#panels#info])
     call s:call('splash', 'sync', 0, {
       \ 'version': b:coqtail_version.str_version,
-      \ 'width': winwidth(l:info_win),
-      \ 'height': winheight(l:info_win)})
+      \ 'width': winwidth(l:info_winid),
+      \ 'height': winheight(l:info_winid)})
     call s:call('refresh', '', 0, {})
 
     call s:init_proof_diffs(b:coqtail_version.str_version)

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -236,11 +236,11 @@ function! coqtail#panels#hide() abort
   let l:toclose = []
   for l:panel in g:coqtail#panels#aux
     let l:buf = b:coqtail_panel_bufs[l:panel]
-    let l:winnr = bufwinnr(l:buf)
-    call setbufvar(l:buf, 'coqtail_panel_open', l:winnr != -1)
-    call setbufvar(l:buf, 'coqtail_panel_size', [winwidth(l:winnr), winheight(l:winnr)])
+    let l:winid = bufwinid(l:buf)
+    call setbufvar(l:buf, 'coqtail_panel_open', l:winid != -1)
+    call setbufvar(l:buf, 'coqtail_panel_size', [winwidth(l:winid), winheight(l:winid)])
     call setbufvar(l:buf, 'coqtail_panel_richpp', [])
-    if l:winnr != -1
+    if l:winid != -1
       let l:toclose = add(l:toclose, l:buf)
     endif
   endfor


### PR DESCRIPTION
This fixes the bug mentioned [here](https://github.com/whonore/Coqtail/issues/221#issuecomment-920131570) where Coqtail prints an error and then stops updating the Goal panel. The problem was switching to another buffer would close the Goal window, but not reset `b:coqtail_panel_richpp`. Then when `s:replace` is next called it calls `matchdelete` on the old match IDs from the previous window, which no longer exist. This would raise `E803`, and if this happened during an `autocmd` (like handling `sync` on `InsertEnter`) it caused `s:evalexpr` to fail, which in turn made `s:call` fail and print an error about a missing `endif`.

Also use window IDs consistently instead of a mix of IDs and window numbers (`:h window-ID`).