### PR TITLE
Change ambiguous mappings to remove delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased ([master])
 
+### Added
+- `g:coqtail_version_compat` option to re-enable old behaviors after breaking changes.
+  (PR #238)
+
 ### Fixed
 - Change ambiguous default mappings to remove delay.
   **BREAKING**: The default mappings have changed for for `<Plug>CoqGotoDef`
@@ -9,7 +13,8 @@
   `<leader>cgG`), `<Plug>CoqGotoGoalNextStart` (`g]` -> `]g`),
   `<Plug>CoqGotoGoalNextEnd` (`G]` -> `]G`), `<Plug>CoqGotoGoalPrevStart` (`g[`
   -> `[g`), and `<Plug>CoqGotoGoalPrevEnd` (`G[` -> `[G`).
-  See the [README](README.md#mappings) for help changing these defaults.
+  Set `g:coqtail_version_compat = ['1.5']` to enable the old mappings, or see
+  the [README](README.md#mappings) for help changing these defaults.
   (PR #238)
 
 ## [1.5.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased ([master])
 
+### Fixed
+- Change ambiguous default mappings to remove delay.
+  **BREAKING**: The default mappings have changed for for `<Plug>CoqGotoDef`
+  (`<leader>cg` -> `<leader>cgd`), `<Plug>CoqGotoGoalEnd` (`<leader>cGG` ->
+  `<leader>cgG`), `<Plug>CoqGotoGoalNextStart` (`g]` -> `]g`),
+  `<Plug>CoqGotoGoalNextEnd` (`G]` -> `]G`), `<Plug>CoqGotoGoalPrevStart` (`g[`
+  -> `[g`), and `<Plug>CoqGotoGoalPrevEnd` (`G[` -> `[G`).
+  See the [README](README.md#mappings) for help changing these defaults.
+  (PR #238)
+
 ## [1.5.2]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Coqtail provides the following commands (see `:help coqtail` for more details):
 | `CoqToTop` | `<leader>cT` | Rewind to the beginning of the file. |
 | `CoqJumpToEnd` | `<leader>cG` | Move the cursor to the end of the checked region. |
 | `CoqJumpToError` | `<leader>cE` | Move the cursor to the start of the error region. |
-| `CoqGotoDef[!] <arg>` | `<leader>cg` | Populate the quickfix list with possible locations of the definition of `<arg>` and try to jump to the first one. If your Vim supports `'tagfunc'` you can also use `CTRL-]`, `:tag`, and friends. |
+| `CoqGotoDef[!] <arg>` | `<leader>cgd` | Populate the quickfix list with possible locations of the definition of `<arg>` and try to jump to the first one. If your Vim supports `'tagfunc'` you can also use `CTRL-]`, `:tag`, and friends. |
 | **Queries** | |
 | `Coq <args>` | | Send arbitrary queries to Coq (e.g. `Check`, `About`, `Print`, etc.). |
 | `Coq Check <arg>` | `<leader>ch` | Show the type of `<arg>` (the mapping will use the term under the cursor or the highlighted range in visual mode). |
@@ -80,11 +80,11 @@ Coqtail provides the following commands (see `:help coqtail` for more details):
 | **Panel Management** | |
 | `CoqRestorePanels` | `<leader>cr` | Re-open the Goal and Info panels. |
 | `{n}CoqGotoGoal` | `<leader>cgg` | Scroll the Goal panel to the start of the `n`th goal (defaults to 1). Number of lines shown is controlled by `g:coqtail_goal_lines`. |
-| `{n}CoqGotoGoal!` | `<leader>cGG` | Scroll the Goal panel to the end of the `n`th goal. |
-| `CoqGotoGoalNext` | `g]` | Scroll the Goal panel to the start of the next goal. |
-| `CoqGotoGoalNext!` | `G]` | Scroll the Goal panel to the end of the next goal. |
-| `CoqGotoGoalPrev` | `g[` | Scroll the Goal panel to the start of the previous goal. |
-| `CoqGotoGoalPrev!` | `G[` | Scroll the Goal panel to the end of the previous goal. |
+| `{n}CoqGotoGoal!` | `<leader>cgG` | Scroll the Goal panel to the end of the `n`th goal. |
+| `CoqGotoGoalNext` | `]g` | Scroll the Goal panel to the start of the next goal. |
+| `CoqGotoGoalNext!` | `]G` | Scroll the Goal panel to the end of the next goal. |
+| `CoqGotoGoalPrev` | `[g` | Scroll the Goal panel to the start of the previous goal. |
+| `CoqGotoGoalPrev!` | `[G` | Scroll the Goal panel to the end of the previous goal. |
 
 ## Configuration
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -514,7 +514,7 @@ function! coqtail#define_mappings() abort
     \ ['ToTop', 'T', 'ni'],
     \ ['JumpToEnd', 'G', 'ni'],
     \ ['JumpToError', 'E', 'ni'],
-    \ ['GotoDef', 'g', 'n'],
+    \ ['GotoDef', 'gd', 'n'],
     \ ['Search', 's', 'nx'],
     \ ['Check', 'h', 'nx'],
     \ ['About', 'a', 'nx'],
@@ -522,11 +522,11 @@ function! coqtail#define_mappings() abort
     \ ['Locate', 'f', 'nx'],
     \ ['RestorePanels', 'r', 'ni'],
     \ ['GotoGoalStart', 'gg', 'ni'],
-    \ ['GotoGoalEnd', 'GG', 'ni'],
-    \ ['GotoGoalNextStart', '!g]', 'n'],
-    \ ['GotoGoalNextEnd', '!G]', 'n'],
-    \ ['GotoGoalPrevStart', '!g[', 'n'],
-    \ ['GotoGoalPrevEnd', '!G[', 'n'],
+    \ ['GotoGoalEnd', 'gG', 'ni'],
+    \ ['GotoGoalNextStart', '!]g', 'n'],
+    \ ['GotoGoalNextEnd', '!]G', 'n'],
+    \ ['GotoGoalPrevStart', '![g', 'n'],
+    \ ['GotoGoalPrevEnd', '![G', 'n'],
     \ ['ToggleDebug', 'd', 'n']
   \]
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -504,33 +504,48 @@ function! coqtail#define_mappings() abort
   let l:map_prefix = get(g:, 'coqtail_map_prefix', '<leader>c')
   let l:imap_prefix = get(g:, 'coqtail_imap_prefix', l:map_prefix)
 
-  let l:maps = [
-    \ ['Start', 'c', 'n'],
-    \ ['Stop', 'q', 'n'],
-    \ ['Interrupt', '!<C-c>', 'n'],
-    \ ['Next', 'j', 'ni'],
-    \ ['Undo', 'k', 'ni'],
-    \ ['ToLine', 'l', 'ni'],
-    \ ['ToTop', 'T', 'ni'],
-    \ ['JumpToEnd', 'G', 'ni'],
-    \ ['JumpToError', 'E', 'ni'],
-    \ ['GotoDef', 'gd', 'n'],
-    \ ['Search', 's', 'nx'],
-    \ ['Check', 'h', 'nx'],
-    \ ['About', 'a', 'nx'],
-    \ ['Print', 'p', 'nx'],
-    \ ['Locate', 'f', 'nx'],
-    \ ['RestorePanels', 'r', 'ni'],
-    \ ['GotoGoalStart', 'gg', 'ni'],
-    \ ['GotoGoalEnd', 'gG', 'ni'],
-    \ ['GotoGoalNextStart', '!]g', 'n'],
-    \ ['GotoGoalNextEnd', '!]G', 'n'],
-    \ ['GotoGoalPrevStart', '![g', 'n'],
-    \ ['GotoGoalPrevEnd', '![G', 'n'],
-    \ ['ToggleDebug', 'd', 'n']
-  \]
+  let l:maps = {
+    \ 'Start': ['c', 'n'],
+    \ 'Stop': ['q', 'n'],
+    \ 'Interrupt': ['!<C-c>', 'n'],
+    \ 'Next': ['j', 'ni'],
+    \ 'Undo': ['k', 'ni'],
+    \ 'ToLine': ['l', 'ni'],
+    \ 'ToTop': ['T', 'ni'],
+    \ 'JumpToEnd': ['G', 'ni'],
+    \ 'JumpToError': ['E', 'ni'],
+    \ 'GotoDef': ['gd', 'n'],
+    \ 'Search': ['s', 'nx'],
+    \ 'Check': ['h', 'nx'],
+    \ 'About': ['a', 'nx'],
+    \ 'Print': ['p', 'nx'],
+    \ 'Locate': ['f', 'nx'],
+    \ 'RestorePanels': ['r', 'ni'],
+    \ 'GotoGoalStart': ['gg', 'ni'],
+    \ 'GotoGoalEnd': ['gG', 'ni'],
+    \ 'GotoGoalNextStart': ['!]g', 'n'],
+    \ 'GotoGoalNextEnd': ['!]G', 'n'],
+    \ 'GotoGoalPrevStart': ['![g', 'n'],
+    \ 'GotoGoalPrevEnd': ['![G', 'n'],
+    \ 'ToggleDebug': ['d', 'n']
+  \}
 
-  for [l:cmd, l:key, l:types] in l:maps
+  " Use v1.5 mappings
+  let l:compat15 = index(get(g:, 'coqtail_version_compat', []), '1.5') != -1
+  if l:compat15
+    let l:maps15 =  {
+      \ 'GotoDef': ['g', 'n'],
+      \ 'GotoGoalEnd': ['GG', 'ni'],
+      \ 'GotoGoalNextStart': ['!g]', 'n'],
+      \ 'GotoGoalNextEnd': ['!G]', 'n'],
+      \ 'GotoGoalPrevStart': ['!g[', 'n'],
+      \ 'GotoGoalPrevEnd': ['!G[', 'n']
+    \}
+    let l:maps = extend(l:maps, l:maps15, 'force')
+  endif
+
+  for [l:cmd, l:info] in items(l:maps)
+    let [l:key, l:types] = l:info
     let l:cmd = '<Plug>Coq' . l:cmd
     for l:type in split(l:types, '\zs')
       if !hasmapto(l:cmd, l:type) && (l:type !=# 'i' || l:imap)

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -531,14 +531,15 @@ function! coqtail#define_mappings() abort
   \]
 
   for [l:cmd, l:key, l:types] in l:maps
+    let l:cmd = '<Plug>Coq' . l:cmd
     for l:type in split(l:types, '\zs')
-      if !hasmapto('<Plug>Coq' . l:cmd, l:type) && (l:type !=# 'i' || l:imap)
+      if !hasmapto(l:cmd, l:type) && (l:type !=# 'i' || l:imap)
         let l:prefix = l:type ==# 'i' ? l:imap_prefix : l:map_prefix
         if l:key[0] ==# '!'
           let l:key = l:key[1:]
           let l:prefix = ''
         endif
-        execute l:type . 'map <buffer> ' . l:prefix . l:key . ' <Plug>Coq' . l:cmd
+        execute printf('%smap <buffer> %s%s %s', l:type, l:prefix, l:key, l:cmd)
       endif
     endfor
   endfor

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -84,9 +84,9 @@ Movement Commands					      *coqtail-movement*
 <leader>cE		Move the cursor to the start of the error region. This
 			does not move the checked region.
 
-				       *<leader>cg* *:CoqGotoDef* *coqtail-goto-def*
+				      *<leader>cgd* *:CoqGotoDef* *coqtail-goto-def*
 :CoqGotoDef[!] {arg}
-<leader>cg		Populate the |quickfix| list with possible locations
+<leader>cgd		Populate the |quickfix| list with possible locations
 			of the definition of a Coq term and try to jump to
 			the first one. If jumping is impossible open the
 			|quickfix-window| instead. The first version uses
@@ -142,32 +142,32 @@ Panel Management						*coqtail-panels*
 
 			[count] default: 1.
 
-						     *<leader>cGG* *:CoqGotoGoal!*
+						     *<leader>cgG* *:CoqGotoGoal!*
 							 *coqtail-goto-goal-end*
 :[count]CoqGotoGoal!
-<count><leader>cGG	Same as `:CoqGotoGoal` but scroll to the end of the
+<count><leader>cgG	Same as `:CoqGotoGoal` but scroll to the end of the
 			goal.
 
-							   *g]* *:CoqGotoGoalNext*
+							   *]g* *:CoqGotoGoalNext*
 						  *coqtail-goto-goal-next-start*
 :CoqGotoGoalNext
-g]			Scroll the Goal panel to the start of the next goal.
+]g			Scroll the Goal panel to the start of the next goal.
 
-							  *G]* *:CoqGotoGoalNext!*
+							  *]G* *:CoqGotoGoalNext!*
 						    *coqtail-goto-goal-next-end*
 :CoqGotoGoalNext!
-G]			Scroll the Goal panel to the end of the next goal.
+]G			Scroll the Goal panel to the end of the next goal.
 
-							   *g[* *:CoqGotoGoalPrev*
+							   *[g* *:CoqGotoGoalPrev*
 						  *coqtail-goto-goal-prev-start*
 :CoqGotoGoalPrev
-g[			Scroll the Goal panel to the start of the previous
+[g			Scroll the Goal panel to the start of the previous
 			goal.
 
-							  *G[* *:CoqGotoGoalPrev!*
+							  *[G* *:CoqGotoGoalPrev!*
 						    *coqtail-goto-goal-prev-end*
 :CoqGotoGoalPrev!
-G[			Scroll the Goal panel to the end of the previous goal.
+[G			Scroll the Goal panel to the end of the previous goal.
 
 =============
 Configuration						 *coqtail-configuration*

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -13,7 +13,8 @@ using standard Vim methods (e.g., the |argument-list| or |buffer-list|).
 3. Coq Queries				|coqtail-queries|
 4. Panel Management			|coqtail-panels|
 5. Configuration			|coqtail-configuration|
-6. Debugging				|coqtail-debug|
+6. Backwards Compatibility		|coqtail-backwards-compatibility|
+7. Debugging				|coqtail-debug|
 
 =============================
 Starting and Stopping Coqtail				    *coqtail-start-stop*
@@ -297,6 +298,25 @@ b:coqtail_auto_set_proof_diffs
 			`on`, `off`, or `removed`.
 
 			Default: ''
+
+=======================
+Backwards Compatibility			       *coqtail-backwards-compatibility*
+
+
+			       *g:coqtail_version_compat* *coqtail-version-compat*
+g:coqtail_version_compat
+			New versions of Coqtail should generally maintain
+			backwards compatibility with old ones, but in cases
+			where they do not the old behaviors can be enabled by
+			including the correct version string in the
+			`g:coqtail_version_compat` list. The table below lists
+			the valid version strings and their effects.
+
+			Default: []
+
+Version	Effect~
+						    *coqtail-version-compat-1.5*
+'1.5'	Undo the changes to the default mappings made in v1.6.
 
 =========
 Debugging							 *coqtail-debug*


### PR DESCRIPTION
Fix #171 #236.

I don't like changing these mappings without having some sort of deprecation warning first, but I can't think of a good alternative. The usual solution I've seen in other Vim plugins is to keep the old mapping but have it print a warning. But that doesn't really work here since the only way I see to remove the delay is to remove the ambiguous mappings.

I'll leave this open for a bit to see if anyone has any suggestions for a better option.

CC @tomtomjhj @ana-borges @j-hui
