### PR TITLE
Catch long Coqtail warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   (PR #266)
 
 ### Fixed
+- Catch and report long warnings from Coqtop that line wrap (`Warning:\n`
+  instead of `Warning: `) instead of aborting.
+  (PR #274)
 - Broken highlighting and indentation after `Fail Next Obligation`.
   (PR #268)
 - Highlight many more tactics.

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -50,7 +50,7 @@ Goals = NamedTuple(
     ],
 )
 
-WARNING_RE = re.compile("^(Warning: [^]]+])$", flags=re.MULTILINE)
+WARNING_RE = re.compile("^(Warning:[^]]+])$", flags=re.MULTILINE)
 
 
 class FindCoqtopError(Exception):

--- a/tests/coq/test_coqtop.py
+++ b/tests/coq/test_coqtop.py
@@ -246,10 +246,21 @@ def test_start_invalid_option() -> None:
     assert stderr == ""
 
 
-def test_start_warning() -> None:
+@pytest.mark.parametrize(
+    "args",
+    (
+        ["-R", "fake", "Fake"],
+        [
+            "-R",
+            "very-long-fake-file-name-that-forces-the-warning-to-wrap-to-a-new-line",
+            "Fake",
+        ],
+    ),
+)
+def test_start_warning(args: List[str]) -> None:
     """Warnings do not cause startup to fail."""
     ct = Coqtop()
-    res, stderr = ct.start(None, None, "", ["-R", "fake", "Fake"])
+    res, stderr = ct.start(None, None, "", args)
     assert isinstance(res, dict)
     assert ct.xml is not None
     # Some versions of Coq don't print warnings in the expected format.


### PR DESCRIPTION
If the warning message is long enough Coq prints `Warning:\n...` instead of `Warning: ...`. Fixes #273.