### PR TITLE
Strip trailing whitespace from splash screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   (PR #266)
 
 ### Fixed
+- Strip trailing whitespace from the splash screen to make it less ugly when
+  `list` + `listchars=trail:` is set.
+  (PR #284)
 - Catch and report long warnings from Coqtop that line wrap (`Warning:\n`
   instead of `Warning: `) instead of aborting.
   (PR #274)

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -712,6 +712,7 @@ class Coqtail:
         # Center vertically if the Info panel is empty.
         if self.info_msg == []:
             msg = [""] * ((height // 2) - (len(msg) // 2 + 1)) + msg
+        msg = [line.rstrip() for line in msg]
         self.set_info(msg, reset=False)
 
     def toggle_debug(self, opts: VimOptions) -> None:


### PR DESCRIPTION
Reasonable people everywhere may now rejoice.