### PR TITLE
Support undo in auxiliary panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   (PR #300)
 
 ### Fixed
+- Set the undo history for the Goal and Info panels on updates.
+  (PR #302)
 - Incorrect indentation of a line following a comment.
   (PR #299)
 - Highlight hypotheses separated by a comma on the first line of the hypotheses

--- a/autoload/coqtail/compat.vim
+++ b/autoload/coqtail/compat.vim
@@ -53,6 +53,13 @@ else
   endfunction
 endif
 
+" Replace the entire contents of a buffer.
+function! coqtail#compat#replacelines(lines) abort
+  call coqtail#compat#deleteline(1, '$')
+  call append(0, a:lines) " this leaves an empty line at the bottom
+  call coqtail#compat#deleteline('$', '$')
+endfunction
+
 function! coqtail#compat#init(python_dir) abort
   " Workaround for a NeoVim bug where py3eval returns v:null the first time
   " it's called.

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -267,9 +267,7 @@ function! s:replace(panel, txt, richpp, scroll) abort
   let l:old = l:old ==# [''] ? [] : l:old
   if l:old !=# a:txt
     let &l:undolevels = &l:undolevels " explicitly break undo sequence
-    call coqtail#compat#deleteline(1, '$')
-    call append(0, a:txt) " this leaves an empty line at the bottom
-    call coqtail#compat#deleteline('$', '$')
+    call coqtail#compat#replacelines(a:txt)
   endif
 
   " Set new highlights

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -263,9 +263,9 @@ function! s:replace(panel, txt, richpp, scroll) abort
   endfor
 
   " Update buffer text
-  let old = getline(1, '$') " returns [''] for empty buffer
-  let old = (old ==# ['']) ? [] : old
-  if old !=# a:txt
+  let l:old = getline(1, '$') " returns [''] for empty buffer
+  let l:old = l:old ==# [''] ? [] : l:old
+  if l:old !=# a:txt
     let &l:undolevels = &l:undolevels " explicitly break undo sequence
     call coqtail#compat#deleteline(1, '$')
     call append(0, a:txt) " this leaves an empty line at the bottom

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -60,6 +60,7 @@ function! s:init(name) abort
   setlocal nobuflisted
   setlocal nocursorline
   setlocal wrap
+  setlocal undolevels=50
 
   let b:coqtail_panel_open = 1
   let b:coqtail_panel_size = [-1, -1]
@@ -262,8 +263,14 @@ function! s:replace(panel, txt, richpp, scroll) abort
   endfor
 
   " Update buffer text
-  call coqtail#compat#deleteline(1, '$')
-  call append(0, a:txt)
+  let old = getline(1, '$') " returns [''] for empty buffer
+  let old = (old ==# ['']) ? [] : old
+  if old !=# a:txt
+    let &l:undolevels = &l:undolevels " explicitly break undo sequence
+    call coqtail#compat#deleteline(1, '$')
+    call append(0, a:txt) " this leaves an empty line at the bottom
+    call coqtail#compat#deleteline('$', '$')
+  endif
 
   " Set new highlights
   let l:matches = []

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -266,7 +266,7 @@ function! s:replace(panel, txt, richpp, scroll) abort
   let l:old = getline(1, '$') " returns [''] for empty buffer
   let l:old = l:old ==# [''] ? [] : l:old
   if l:old !=# a:txt
-    let &l:undolevels = &l:undolevels " explicitly break undo sequence
+    let &l:undolevels = &l:undolevels " explicitly break undo sequence (:h undo-break)
     call coqtail#compat#replacelines(a:txt)
   endif
 


### PR DESCRIPTION
Problem: To see result of past commands, users have to step backward or
re-run the (query) command. This is not great since the command can be
slow. Another solution is to run Vim's undo command in the panels, but
this doesn't work, since "One undo command normally undoes a typed
command" (:help undo-blocks), while the panel update is done
asynchronously without a command being typed.

Solution: Break undo sequence when updating auxiliary panerls.