### PR TITLE
Explicitly select and ignore all flake8 warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,12 @@
 [flake8]
-extend-ignore =
+select = B, E, F, W
+ignore =
     # whitespace before ':'
     E203,
     # line too long
     E501,
-    # function is too complex
-    C901
-select = B, E, F, W
+    # line break before binary operator
+    W503
 
 [mypy]
 mypy_path = $MYPY_CONFIG_FILE_DIR/python/


### PR DESCRIPTION
Adjust to the way [flake8 5.0](https://flake8.pycqa.org/en/latest/release-notes/5.0.0.html) combines implicit/explicit ignored/selected warnings.