### PR TITLE
Remove unrecognized mypy option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ warn_unused_configs = True
 color_output = True
 pretty = True
 show_error_codes = True
-show_none_errors = True
 allow_redefinition = True
 allow_untyped_globals = False
 check_untyped_defs = True


### PR DESCRIPTION
No longer needed after MyPy [0.991](https://mypy-lang.blogspot.com/2022/11/mypy-0990-released.html).