### PR TITLE
Specify exact Python version for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         coq_version: ['8.4', '8.5', '8.6', '8.7', '8.8', '8.9', '8.10', '8.11', '8.12', '8.13', '8.14', '8.15', '8.16', 'master']
-        py_version: [3.6]
+        py_version: ['3.6.15']
     steps:
       - uses: actions/checkout@v2
       - name: Install Nix
@@ -38,7 +38,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
       - name: Run Coq tests
-        if: matrix.py_version == '3.6'
+        if: startsWith(matrix.py_version, '3.6')
         run: |
           coqtop --version
           python --version
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        py_version: [3.6]
+        py_version: ['3.6.15']
     steps:
       - uses: actions/checkout@v2
       - name: Install Python ${{ matrix.py_version }}
@@ -61,7 +61,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
       - name: Run Python tests
-        if: matrix.py_version == '3.6'
+        if: startsWith(matrix.py_version, '3.6')
         run: |
           python --version
           tox -e unit-py36


### PR DESCRIPTION
Fix for failing CI due to `setup-python` not finding the correct version. See https://github.com/whonore/Coqtail/actions/runs/3569119053/jobs/6009427437#step:6:9.