### PR TITLE
Use `Add` when `SetOptions` fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   (PR #309)
 
 ### Fixed
+- Fall back to using `Add` to set options if a best-effort attempt at using
+  `SetOptions` fails.
+  (PR #318)
 - Use a no-op command that does not hang with `-noinit`.
   (PR #313)
 - Joining comments with `J` while the `j` flag is set in `'formatoptions'` does


### PR DESCRIPTION
Fixes #317.

I started implementing a smarter option parsing solution by using `GetOptions` to learn the available options and their types, but it was becoming way too complicated handling all the edge cases. The current approach to guessing the option type is a bit hacky, but it works for almost everything, so I'm leaving it for now and just using `Add` when it fails. 

I think it's still better to try to use `SetOptions` when possible because it seems more in line with the intended usage of the XML protocol and, for certain options (e.g., `Diffs`), Coqtop prints an annoying warning about setting it from the IDE menu.