### PR TITLE
Option to omit proofs up to line

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -174,6 +174,7 @@ disable=blacklisted-name,
         too-many-public-methods,
         too-many-return-statements,
         too-many-statements,
+        unsubscriptable-object,
         wrong-spelling-in-comment,
         wrong-spelling-in-docstring,
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased ([master])
 
 ### Added
-- A command (`CoqToLine!`) to advance to a given line while omitting the body of
-  and admitting all intervening opaque proofs.
+- A command (`CoqOmitToLine`) to advance to a given line while omitting the body
+  of and admitting all intervening opaque proofs.
   (PR #321)
 - Display goal names when `Printing Goal Names` is enabled.
   (PR #310)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased ([master])
 
 ### Added
+- A command (`CoqToLine!`) to advance to a given line while omitting the body of
+  and admitting all intervening opaque proofs.
+  (PR #321)
 - Display goal names when `Printing Goal Names` is enabled.
   (PR #310)
 - Support for the `Subgoals` XML command (>= 8.16 only).

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Coqtail provides the following commands (see `:help coqtail` for more details):
 | `{n}CoqNext` | `<leader>cj` | Send the next `n` (1 by default) sentences to Coq. |
 | `{n}CoqUndo` | `<leader>ck` | Step back `n` (1 by default) sentences. |
 | `{n}CoqToLine` | `<leader>cl` | Send/rewind all sentences up to line `n` (cursor position by default). `n` can also be `$` to check the entire buffer. |
+| `{n}CoqOmitToLine` | No default (see [Mappings](#mappings)) | Same as `CoqToLine`, but skip processing of and admit all opaque proofs. Similar to Proof General's [`proof-omit-proofs-option`](https://proofgeneral.github.io/doc/master/userman/Coq-Proof-General/#Omitting-proofs-for-speed). See `:help CoqOmitToLine` for more information. |
 | `CoqToTop` | `<leader>cT` | Rewind to the beginning of the file. |
 | `CoqJumpToEnd` | `<leader>cG` | Move the cursor to the end of the checked region. |
 | `CoqJumpToError` | `<leader>cE` | Move the cursor to the start of the error region. |
@@ -137,7 +138,8 @@ Formatting of comments can be disabled with `g:coqtail_noindent_comment`.
 
 In addition to the Coq syntax, Coqtail defines highlighting groups for the
 sentences that are currently or have already been checked by Coq (`CoqtailSent`
-and `CoqtailChecked`) as well as any lines that raised an error (`CoqtailError`).
+and `CoqtailChecked`), any lines that raised an error (`CoqtailError`), and the
+beginnings and ends of omitted proofs (`CoqtailOmitted`).
 By default these are defined as:
 
 ```vim
@@ -149,6 +151,7 @@ else
   hi def CoqtailSent    ctermbg=7 guibg=LimeGreen
 endif
 hi def link CoqtailError Error
+hi def link CoqtailOmitted coqProofAdmit
 ```
 
 To override these defaults simply set your own highlighting (`:help :hi`) before

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -435,7 +435,8 @@ let s:cmd_opts = {
   \ 'CoqInterrupt': '-bar',
   \ 'CoqNext': '-bar -count=1',
   \ 'CoqUndo': '-bar -count=1',
-  \ 'CoqToLine': '-bar -bang -count=0',
+  \ 'CoqToLine': '-bar -count=0',
+  \ 'CoqOmitToLine': '-bar -count=0',
   \ 'CoqToTop': '-bar',
   \ 'CoqJumpToEnd': '-bar',
   \ 'CoqJumpToError': '-bar',
@@ -465,7 +466,8 @@ function! coqtail#define_commands() abort
   call s:cmddef('CoqInterrupt', 'call s:call("interrupt", "sync", 0, {})', '')
   call s:cmddef('CoqNext', 'call s:call("step", "", 0, {"steps": <count>})', 's')
   call s:cmddef('CoqUndo', 'call s:call("rewind", "", 0, {"steps": <count>})', 's')
-  call s:cmddef('CoqToLine', 'call coqtail#toline(<count>, <bang>0)', 's')
+  call s:cmddef('CoqToLine', 'call coqtail#toline(<count>, 0)', 's')
+  call s:cmddef('CoqOmitToLine', 'call coqtail#toline(<count>, 1)', 's')
   call s:cmddef('CoqToTop', 'call s:call("to_top", "", 0, {})', 's')
   call s:cmddef('CoqJumpToEnd', 'call coqtail#jumpto("endpoint")', 's')
   call s:cmddef('CoqJumpToError', 'call coqtail#jumpto("errorpoint")', 's')
@@ -487,12 +489,14 @@ function! coqtail#define_mappings() abort
   nnoremap <buffer> <silent> <Plug>CoqNext :<C-U>execute v:count1 'CoqNext'<CR>
   nnoremap <buffer> <silent> <Plug>CoqUndo :<C-U>execute v:count1 'CoqUndo'<CR>
   nnoremap <buffer> <silent> <Plug>CoqToLine :<C-U>execute v:count 'CoqToLine'<CR>
+  nnoremap <buffer> <silent> <Plug>CoqOmitToLine :<C-U>execute v:count 'CoqOmitToLine'<CR>
   nnoremap <buffer> <silent> <Plug>CoqToTop :CoqToTop<CR>
   nnoremap <buffer> <silent> <Plug>CoqJumpToEnd :CoqJumpToEnd<CR>
   nnoremap <buffer> <silent> <Plug>CoqJumpToError :CoqJumpToError<CR>
   inoremap <buffer> <silent> <Plug>CoqNext <C-\><C-o>:CoqNext<CR>
   inoremap <buffer> <silent> <Plug>CoqUndo <C-\><C-o>:CoqUndo<CR>
   inoremap <buffer> <silent> <Plug>CoqToLine <C-\><C-o>:CoqToLine<CR>
+  inoremap <buffer> <silent> <Plug>CoqOmitToLine <C-\><C-o>:CoqOmitToLine<CR>
   inoremap <buffer> <silent> <Plug>CoqToTop <C-\><C-o>:CoqToTop<CR>
   inoremap <buffer> <silent> <Plug>CoqJumpToEnd <C-\><C-o>:CoqJumpToEnd<CR>
   inoremap <buffer> <silent> <Plug>CoqJumpToError <C-\><C-o>:CoqJumpToError<CR>

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -397,12 +397,13 @@ function! coqtail#stop() abort
 endfunction
 
 " Advance/rewind Coq to the specified position.
-function! coqtail#toline(line) abort
+function! coqtail#toline(line, admit) abort
   " If no line was given then use the cursor's position,
   " otherwise use the last column in the line
   call s:call('to_line', '', 0, {
     \ 'line': (a:line == 0 ? line('.') : a:line) - 1,
-    \ 'col': (a:line == 0 ? col('.') : len(getline(a:line))) - 1})
+    \ 'col': (a:line == 0 ? col('.') : len(getline(a:line))) - 1,
+    \ 'admit': a:admit})
 endfunction
 
 " Move the cursor to the specified target:
@@ -434,7 +435,7 @@ let s:cmd_opts = {
   \ 'CoqInterrupt': '-bar',
   \ 'CoqNext': '-bar -count=1',
   \ 'CoqUndo': '-bar -count=1',
-  \ 'CoqToLine': '-bar -count=0',
+  \ 'CoqToLine': '-bar -bang -count=0',
   \ 'CoqToTop': '-bar',
   \ 'CoqJumpToEnd': '-bar',
   \ 'CoqJumpToError': '-bar',
@@ -464,7 +465,7 @@ function! coqtail#define_commands() abort
   call s:cmddef('CoqInterrupt', 'call s:call("interrupt", "sync", 0, {})', '')
   call s:cmddef('CoqNext', 'call s:call("step", "", 0, {"steps": <count>})', 's')
   call s:cmddef('CoqUndo', 'call s:call("rewind", "", 0, {"steps": <count>})', 's')
-  call s:cmddef('CoqToLine', 'call coqtail#toline(<count>)', 's')
+  call s:cmddef('CoqToLine', 'call coqtail#toline(<count>, <bang>0)', 's')
   call s:cmddef('CoqToTop', 'call s:call("to_top", "", 0, {})', 's')
   call s:cmddef('CoqJumpToEnd', 'call coqtail#jumpto("endpoint")', 's')
   call s:cmddef('CoqJumpToError', 'call coqtail#jumpto("errorpoint")', 's')

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -13,7 +13,8 @@ let g:coqtail#panels#aux = [g:coqtail#panels#goal, g:coqtail#panels#info]
 let s:hlgroups = [
   \ ['coqtail_checked', 'CoqtailChecked'],
   \ ['coqtail_sent', 'CoqtailSent'],
-  \ ['coqtail_error', 'CoqtailError']
+  \ ['coqtail_error', 'CoqtailError'],
+  \ ['coqtail_omitted', 'CoqtailOmitted']
 \]
 let s:richpp_hlgroups = {
   \ 'diff.added': 'CoqtailDiffAdded',
@@ -219,8 +220,10 @@ function! s:updatehl(winid, highlights) abort
   call s:clearhl(a:winid)
   for [l:var, l:grp] in s:hlgroups
     let l:hl = a:highlights[l:var]
-    if l:hl != v:null
+    if type(l:hl) == g:coqtail#compat#t_string
       call setwinvar(a:winid, l:var, matchadd(l:grp, l:hl, -10))
+    elseif type(l:hl) == g:coqtail#compat#t_list
+      call setwinvar(a:winid, l:var, matchaddpos(l:grp, l:hl, -10))
     endif
   endfor
 endfunction

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -72,6 +72,25 @@ Movement Commands					      *coqtail-movement*
 			be moved inside the sentence first, for instance by
 			using `:CoqJumpToError` first.
 
+								*:CoqOmitToLine*
+							  *coqtail-omit-to-line*
+:[count]CoqOmitToLine	Behaves the same as `:CoqToLine`, but the bodies of
+			all opaque proofs (those ending with "Qed" or
+			"Admitted") are omitted and admitted. This can be
+			useful for quickly jumping to a point towards the end
+			of a large file. The beginnings and ends of omitted
+			proofs (i.e., the "Proof" and "Qed"/"Admitted"
+			commands) are marked by highlighting them with the
+			`CoqtailOmitted` group.
+
+			NOTE: Proofs must begin with "Proof" or "Proof using".
+			NOTE: A proof is considered opaque only if every
+			nested proof it contains is also opaque.
+			NOTE: Proofs inside sections may need to list the
+			variables they depend on with `Proof using` in order
+			to get the right type when the proof body is omitted.
+			See https://coq.inria.fr/distrib/current/refman/proofs/writing-proofs/proof-mode.html#coq:cmd.Proof-using.
+
 					     *<leader>cT* *i_<leader>cT* *:CoqToTop*
 								*coqtail-to-top*
 :CoqToTop	or

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -265,7 +265,7 @@ class Coqtail:
         self.omitted_proofs = [
             range_
             for range_ in self.omitted_proofs
-            if range_.qed["stop"] <= self.endpoints[-1]
+            if self.endpoints != [] and range_.qed["stop"] <= self.endpoints[-1]
         ]
         self.error_at = None
         self.refresh(opts=opts)

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -46,6 +46,7 @@ if !exists('b:coqtail_did_highlight') || !b:coqtail_did_highlight
     hi def link CoqtailDiffRemoved DiffDelete
     hi def link CoqtailDiffRemovedBg DiffDelete
     hi def link CoqtailError Error
+    hi def link CoqtailOmitted coqProofAdmit
   endfunction
 
   call s:CoqtailHighlight()

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -153,31 +153,35 @@ CommentTest = Tuple[str, CommentIn, CommentOut]
 
 com_tests: Sequence[CommentTest] = (
     ("no comment", b"abc", (b"abc", [])),
-    ("pre", b"(*abc*)def", (b" def", [(0, 7)])),
-    ("mid", b"ab(* c *)de", (b"ab de", [(2, 7)])),
-    ("post", b"abc(*def *)", (b"abc", [(3, 8)])),
+    ("pre", b"(*abc*)def", (b"       def", [(0, 7)])),
+    ("mid", b"ab(* c *)de", (b"ab       de", [(2, 7)])),
+    ("post", b"abc(*def *)", (b"abc        ", [(3, 8)])),
     (
         "multi",
         b"abc (* com1 *)  def (*com2 *) g",
-        (b"abc    def   g", [(4, 10), (20, 9)]),
+        (b"abc             def           g", [(4, 10), (20, 9)]),
     ),
-    ("nested", b"abc (* c1 (*c2 (*c3*) (*c4*) *) *)def", (b"abc  def", [(4, 30)])),
+    (
+        "nested",
+        b"abc (* c1 (*c2 (*c3*) (*c4*) *) *)def",
+        (b"abc                               def", [(4, 30)]),
+    ),
     ("no comment newline", b"\nabc\n\n", (b"\nabc\n\n", [])),
-    ("pre newline", b"(*ab\nc*)d\nef", (b" d\nef", [(0, 8)])),
-    ("mid newline", b"ab(* c *)\nde", (b"ab \nde", [(2, 7)])),
-    ("post newline", b"abc\n(*def *)\n", (b"abc\n \n", [(4, 8)])),
+    ("pre newline", b"(*ab\nc*)d\nef", (b"    \n   d\nef", [(0, 8)])),
+    ("mid newline", b"ab(* c *)\nde", (b"ab       \nde", [(2, 7)])),
+    ("post newline", b"abc\n(*def *)\n", (b"abc\n        \n", [(4, 8)])),
     (
         "multi newline",
         b"abc (* com1 *)\n def \n(*\ncom2 *) g",
-        (b"abc  \n def \n  g", [(4, 10), (21, 10)]),
+        (b"abc           \n def \n  \n        g", [(4, 10), (21, 10)]),
     ),
     (
         "nested newline",
         b"\nabc (* c1 (*c2 \n\n(*c3\n*) (*c4*) *) *)def\n",
-        (b"\nabc  def\n", [(5, 33)]),
+        (b"\nabc            \n\n    \n               def\n", [(5, 33)]),
     ),
     ("star paren", b"abc *)", (b"abc *)", [])),
-    ("star paren post comment", b"(*abc*) *)", (b"  *)", [(0, 7)])),
+    ("star paren post comment", b"(*abc*) *)", (b"        *)", [(0, 7)])),
 )
 
 
@@ -266,6 +270,7 @@ Defined.
 Lemma L13 : True.
 Proof.
   idtac "L13".
+  auto.
   (*
   Lemma L14 : True.
   Proof.
@@ -273,12 +278,12 @@ Proof.
     auto.
   Qed.
   *)
-  auto.
 Qed.
 
 Lemma L15 : True.
 Proof.
   idtac "L15".
+  auto.
   (*
   Lemma L16 : True.
   Proof.
@@ -286,34 +291,39 @@ Proof.
     auto.
   Qed.
   *)
-  auto.
 Defined.
 
 Lemma L17 : True.
-Proof using Type.
+Proof.
   idtac "L17".
   auto.
-Qed.
+Qed (* *).
 
 Lemma L18 : True.
 Proof using Type.
   idtac "L18".
   auto.
-Defined.
+Qed.
 
 Lemma L19 : True.
-Proof. idtac "L19". auto. Qed.
+Proof using Type.
+  idtac "L19".
+  auto.
+Defined.
 
 Lemma L20 : True.
-Proof.
-  idtac "L20".
-  auto.
-\t
-  Qed.
+Proof. idtac "L20". auto. Qed.
 
 Lemma L21 : True.
 Proof.
   idtac "L21".
+  auto.
+\t
+  Qed.
+
+Lemma L22 : True.
+Proof.
+  idtac "L22".
 """
     )
     .strip()
@@ -332,11 +342,12 @@ pend_tests: Sequence[PEndTest] = (
     ("defined in defined", "L11", None),
     ("comment qed", "L13", {"start": (79, 0), "stop": (79, 3)}),
     ("comment defined", "L15", None),
-    ("qed using", "L17", {"start": (98, 0), "stop": (98, 3)}),
-    ("defined using", "L18", None),
-    ("qed same line", "L19", {"start": (107, 26), "stop": (107, 29)}),
-    ("qed extra spaces", "L20", {"start": (114, 2), "stop": (114, 5)}),
-    ("unclosed", "L21", None),
+    ("comment after qed", "L13", {"start": (79, 0), "stop": (79, 3)}),
+    ("qed using", "L18", {"start": (104, 0), "stop": (104, 3)}),
+    ("defined using", "L19", None),
+    ("qed same line", "L20", {"start": (113, 26), "stop": (113, 29)}),
+    ("qed extra spaces", "L21", {"start": (120, 2), "stop": (120, 5)}),
+    ("unclosed", "L22", None),
 )
 
 

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -290,8 +290,20 @@ Proof.
 Defined.
 
 Lemma L17 : True.
-Proof.
+Proof using Type.
   idtac "L17".
+  auto.
+Qed.
+
+Lemma L18 : True.
+Proof using Type.
+  idtac "L18".
+  auto.
+Defined.
+
+Lemma L19 : True.
+Proof.
+  idtac "L19".
 """
     )
     .strip()
@@ -309,7 +321,9 @@ pend_tests: Sequence[PEndTest] = (
     ("defined in defined", "L11", None),
     ("comment qed", "L13", {"start": (79, 0), "stop": (79, 3)}),
     ("comment defined", "L15", None),
-    ("unclosed", "L17", None),
+    ("qed using", "L17", {"start": (98, 0), "stop": (98, 3)}),
+    ("defined using", "L18", None),
+    ("unclosed", "L19", None),
 )
 
 

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -266,6 +266,32 @@ Defined.
 Lemma L13 : True.
 Proof.
   idtac "L13".
+  (*
+  Lemma L14 : True.
+  Proof.
+    idtac "L14".
+    auto.
+  Qed.
+  *)
+  auto.
+Qed.
+
+Lemma L15 : True.
+Proof.
+  idtac "L15".
+  (*
+  Lemma L16 : True.
+  Proof.
+    idtac "L16".
+    auto.
+  Qed.
+  *)
+  auto.
+Defined.
+
+Lemma L17 : True.
+Proof.
+  idtac "L17".
 """
     )
     .strip()
@@ -281,7 +307,9 @@ pend_tests: Sequence[PEndTest] = (
     ("qed in defined", "L7", None),
     ("defined in qed", "L9", None),
     ("defined in defined", "L11", None),
-    ("unclosed", "L13", None),
+    ("comment qed", "L13", {"start": (79, 0), "stop": (79, 3)}),
+    ("comment defined", "L15", None),
+    ("unclosed", "L17", None),
 )
 
 


### PR DESCRIPTION
Add an option to `CoqToLine` (`CoqToLine!`) to omit the body of and admit all opaque proofs (those ending in `Qed` or `Admitted`) up to the specified line. Works similarly to Proof General's [`proof-omit-proofs-option`](https://proofgeneral.github.io/doc/master/userman/Coq-Proof-General/#Omitting-proofs-for-speed).

Caveats:
- Proofs must begin with `Proof`.
- A proof is considered non-opaque and is not omitted if it contains a nested non-opaque proof.
- Proofs in sections may need to list the variables they depend on with `Proof using` in order to get the right type when the proof body is omitted.

Closes #320.

TODO:
- [x] Highlight omitted proof start and end.
- [x] Documentation.