### PR TITLE
Address pylint configuration warning

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -235,7 +235,7 @@ signature-mutators=
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception
 
 
 [VARIABLES]


### PR DESCRIPTION
> pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.Exception' ?) instead.