### PR TITLE
Use more discrete colors in dark backgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 - Support for Coq 8.17.
   (PR #324)
 
+### Fixed
+- Adjusted the default dark-mode GUI colors for `CoqtailChecked` and
+  `CoqtailSent` to make them more legible.
+  See the [README](README.md#syntax-highlighting-and-indentation) for help
+  overriding these defaults.
+  (PR #325)
+
 ## [1.7.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -144,8 +144,13 @@ By default these are defined as:
 
 ```vim
 if &t_Co > 16
-  hi def CoqtailChecked ctermbg=17 guibg=LightGreen
-  hi def CoqtailSent    ctermbg=60 guibg=LimeGreen
+  if &background ==# 'dark'
+    hi def CoqtailChecked ctermbg=17 guibg=#113311
+    hi def CoqtailSent    ctermbg=60 guibg=#007630
+  else
+    hi def CoqtailChecked ctermbg=17 guibg=LightGreen
+    hi def CoqtailSent    ctermbg=60 guibg=LimeGreen
+  endif
 else
   hi def CoqtailChecked ctermbg=4 guibg=LightGreen
   hi def CoqtailSent    ctermbg=7 guibg=LimeGreen

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -35,8 +35,13 @@ if !exists('b:coqtail_did_highlight') || !b:coqtail_did_highlight
       " `autocmd ColorScheme` instead.
       call g:CoqtailHighlight()
     elseif &t_Co > 16
-      hi def CoqtailChecked ctermbg=17 guibg=LightGreen
-      hi def CoqtailSent ctermbg=60 guibg=LimeGreen
+      if &background == "dark"
+        hi def CoqtailChecked ctermbg=17 guibg=#113311
+        hi def CoqtailSent ctermbg=60 guibg=#007630
+      else
+        hi def CoqtailChecked ctermbg=17 guibg=LightGreen
+        hi def CoqtailSent ctermbg=60 guibg=LimeGreen
+      endif
     else
       hi def CoqtailChecked ctermbg=4 guibg=LightGreen
       hi def CoqtailSent ctermbg=7 guibg=LimeGreen

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -35,7 +35,7 @@ if !exists('b:coqtail_did_highlight') || !b:coqtail_did_highlight
       " `autocmd ColorScheme` instead.
       call g:CoqtailHighlight()
     elseif &t_Co > 16
-      if &background == "dark"
+      if &background ==# 'dark'
         hi def CoqtailChecked ctermbg=17 guibg=#113311
         hi def CoqtailSent ctermbg=60 guibg=#007630
       else


### PR DESCRIPTION
I recently started learning Coq, and when I installed this extension the first thing I noticed was that the `CoqtailSent` and `CoqtailChecked`'s `guibg` values were too bright with my dark colorscheme. I fixed it locally by overwriting the highliights in my `vimrc`, but I figured this could be a change others would benefit from.

The colors themselves are just something I thought worked fine. I've also decided to leave the `ctermbg` values unchanged, since I couldn't find a way to open a vim session which used less than 16 colors, so I wasn't able to test different options.