### PR TITLE
Show highlights for a buffer iff the window displays that buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   See the [README](README.md#syntax-highlighting-and-indentation) for help
   overriding these defaults.
   (PR #325)
+- Refresh proof-progress highlighting correctly when entering/leaving a buffer
+  that is open in multiple windows.
+  (PR #327)
 
 ## [1.7.0]
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -286,6 +286,12 @@ function! coqtail#init() abort
       autocmd VimLeavePre *
         \ call py3eval('CoqtailServer.stop_server()') | let s:port = -1
     augroup END
+
+    " Clear Coqtail highlights when window shows an unrelated buffer.
+    augroup coqtail#CleanupHighlights
+      autocmd! *
+      autocmd BufEnter * call coqtail#panels#cleanuphl()
+    augroup END
   endif
 
   if !s:initted()

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -11,10 +11,10 @@ let g:coqtail#panels#info = 'info'
 let g:coqtail#panels#aux = [g:coqtail#panels#goal, g:coqtail#panels#info]
 " Highlighting groups.
 let s:hlgroups = [
-  \ ['coqtail_checked', 'CoqtailChecked'],
-  \ ['coqtail_sent', 'CoqtailSent'],
-  \ ['coqtail_error', 'CoqtailError'],
-  \ ['coqtail_omitted', 'CoqtailOmitted']
+  \ ['checked', 'CoqtailChecked'],
+  \ ['sent', 'CoqtailSent'],
+  \ ['error', 'CoqtailError'],
+  \ ['omitted', 'CoqtailOmitted']
 \]
 let s:richpp_hlgroups = {
   \ 'diff.added': 'CoqtailDiffAdded',
@@ -204,22 +204,26 @@ endfunction
 
 " Clear Coqtop highlighting of the current window
 function! s:clearhl() abort
+  if !exists('w:coqtail_highlights')
+    return
+  endif
   for [l:var, l:_] in s:hlgroups
-    let l:matches = get(w:, l:var, [])
+    let l:matches = get(w:coqtail_highlights, l:var, [])
     for l:match in l:matches
       call matchdelete(l:match)
     endfor
-    unlet! w:{l:var}
   endfor
+  unlet! w:coqtail_highlights
 endfunction
 
 " Update highlighting of the current window.
 function! s:updatehl(highlights) abort
   call s:clearhl()
+  let w:coqtail_highlights = {}
   for [l:var, l:grp] in s:hlgroups
     let l:hl = a:highlights[l:var]
     if type(l:hl) == g:coqtail#compat#t_string
-      let w:{l:var} = [matchadd(l:grp, l:hl, -10)]
+      let w:coqtail_highlights[l:var] = [matchadd(l:grp, l:hl, -10)]
     elseif type(l:hl) == g:coqtail#compat#t_list
       " NOTE: add positions one at a time to work around 8-position maximum in
       " older Vims.
@@ -227,7 +231,7 @@ function! s:updatehl(highlights) abort
       for l:pos in l:hl
         let l:matches = add(l:matches, matchaddpos(l:grp, [l:pos], -10))
       endfor
-      let w:{l:var} = l:matches
+      let w:coqtail_highlights[l:var] = l:matches
     endif
   endfor
 endfunction

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -699,24 +699,24 @@ class Coqtail:
     def highlights(self) -> Dict[str, Optional[Union[str, List[Tuple[int, int, int]]]]]:
         """Vim match patterns for highlighting."""
         matches: Dict[str, Optional[Union[str, List[Tuple[int, int, int]]]]] = {
-            "coqtail_checked": None,
-            "coqtail_sent": None,
-            "coqtail_error": None,
-            "coqtail_omitted": None,
+            "checked": None,
+            "sent": None,
+            "error": None,
+            "omitted": None,
         }
 
         if self.endpoints != []:
             line, col = self.endpoints[-1]
-            matches["coqtail_checked"] = matcher[: line + 1, :col]
+            matches["checked"] = matcher[: line + 1, :col]
 
         if self.send_queue:
             sline, scol = self.endpoints[-1] if self.endpoints != [] else (0, -1)
             eline, ecol = self.send_queue[-1]["stop"]
-            matches["coqtail_sent"] = matcher[sline : eline + 1, scol:ecol]
+            matches["sent"] = matcher[sline : eline + 1, scol:ecol]
 
         if self.error_at is not None:
             (sline, scol), (eline, ecol) = self.error_at
-            matches["coqtail_error"] = matcher[sline : eline + 1, scol:ecol]
+            matches["error"] = matcher[sline : eline + 1, scol:ecol]
 
         if self.omitted_proofs != []:
             ranges = []
@@ -732,7 +732,7 @@ class Coqtail:
                             else len(self.buffer[line]) - col
                         )
                         ranges.append((line + 1, col + 1, span))
-            matches["coqtail_omitted"] = ranges
+            matches["omitted"] = ranges
 
         return matches
 


### PR DESCRIPTION
Problem: Existing BufWinEnter/BufWinLeave autocmds to refresh/clear
highlight don't work if multiple windows display the same coq buffer,
because they are fired only for the first/last display. As a result,
windows may show irrelevant highlights or not show highlights.

Solution: Record highlight info in b:coqtail_highlights. Record the
source buffer in w:coqtail_highlights along with match IDs. Setup
BufEnter autocmds to check their consistency and update/clear highlights
accordingly.

First two commits are just minor refactoring.
