### PR TITLE
fix typo in autogrp name

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ user-defined highlighting, so it is recommended to place your settings in a
 For example:
 
 ```vim
-augroup CoqtailHighlights
+augroup CoqtailHighlight
   autocmd!
   autocmd ColorScheme *
     \  hi def CoqtailChecked ctermbg=236


### PR DESCRIPTION
Hi,

According to [`syntax/coq.vim`](https://github.com/whonore/Coqtail/blob/ac963d9dc54f175128aa31abc9a08c10ebef1ab3/syntax/coq.vim#L32), the highlighting group name should be `CoqtailHighlight`.

But in the README, it was `CoqtailHighlights` with an extra `s`. It took me a while to find out why this was not working as I was translating the example to Lua and were mostly suspicious about my translation... :sweat_smile:

Hopefully this will save some time to others. :)

Cheers and thanks for this plugin !