### PR TITLE
Fix goals panel when no proof is active on Coq >= 8.16.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased ([main])
 
+### Fixed
+- Fix rendering of goals panel when no proof is active in Coq >= 8.16
+
 ## [1.7.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased ([main])
 
 ### Fixed
-- Fix rendering of goals panel when no proof is active in Coq >= 8.16
+- Fix rendering of goals panel when no proof is active in Coq >= 8.16.
+  (PR #337)
 
 ## [1.7.1]
 

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -364,8 +364,7 @@ class Coqtop:
         if isinstance(response_extra, Err):
             return (False, msgs, None, errs)
 
-        assert response_extra.val is not None, \
-            "proof state changed unexpectedly?"
+        assert response_extra.val is not None, "proof state changed unexpectedly?"
 
         # Merge goals
         goals = Goals(


### PR DESCRIPTION
Traditionally, Coq IDEs used the 'Goals' XML command to get the proof state, which had the downside that the full details of non-foreground goals would get serialized from coqidetop but never displayed. In Coq 8.16, the 'Subgoals' command was added, which allows more precise goal fetching: IDEs can make one Subgoals call to request the focused goal in full detail, and another call to request just the conclusions of the other goals. Coqtail switched to this pattern in v1.7.1.

Unfortunately, the logic for merging results from the two calls was slightly wrong. If the calls return None, then there is no proof in progress, but the logic in Coqtail handled this as if there is an in-progress proof with no remaining goals. This made the Goals panel always show "0 subgoals" even when no proof was in progress.

Fix it. If the first call returns None, there is no proof in progress, and we don't bother to make the second call. Else, we learned that there is a proof in progress and what the foreground goal (if any) is; we make the second call to learn the other goals, and then merge the results and continue as before.

Fixes c077a72329dc30fa22802a3a7de49856cb0f1fca.