### PR TITLE
Better dune support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased ([main])
 
 ### Added
+- Support for Coq projects configured with Dune.
+  See the [README](README.md#project-files) for more information.
+  (PR #347)
 - Preliminary support for Coq 8.20 by adapting to the new type used to report
   error locations.
   (PR #358)

--- a/README.md
+++ b/README.md
@@ -148,10 +148,30 @@ let b:coqtail_coq_path = '/path/to/HoTT'
 let b:coqtail_coq_prog = 'hoqidetop'
 ```
 
-### _CoqProject
+### Project Files
 
-Coqtail understands and will search for `_CoqProject` files on `:CoqStart`.
-Additional or different project files can be specified with `g:coqtail_project_files`.
+There are two standard methods for configuring Coq project settings:
+[`_CoqProject` files](https://coq.inria.fr/refman/practical-tools/utilities.html#building-a-project-with-coqproject-overview),
+and
+[dune projects](https://coq.inria.fr/refman/practical-tools/utilities.html#building-a-coq-project-with-dune).
+Coqtail supports both, and while it should usually do the right thing by
+default, its behavior can be controlled by setting the `g:coqtail_build_system`
+option to one of `'prefer-dune'` (default), `'prefer-coqproject'`, `'dune'`, or
+`'coqproject'`.
+Additional arguments can also be passed to the Coq executable through
+`:CoqStart` (e.g., `:CoqStart -w all`).
+
+#### Dune Settings
+
+Dune projects can be configured to automatically compile the dependencies for
+the current file on `:CoqStart` by setting `g:coqtail_dune_compile_deps = 1`.
+
+#### _CoqProject Settings
+
+By default, Coqtail searches the current and parent directories for a
+`_CoqProject` file, but additional or different project files can be specified
+with `g:coqtail_project_files`.
+If multiple files are found, their argument lists will be concatenated.
 For example, to include arguments from both `_CoqProject` and `_CoqProject.local`:
 
 ```vim
@@ -296,7 +316,7 @@ If you cannot upgrade Vim, the [python2] branch still supports older Pythons.
 [matchup]: https://github.com/andymass/vim-matchup
 [matchit]: http://ftp.vim.org/pub/vim/runtime/macros/matchit.txt
 [endwise]: https://github.com/tpope/vim-endwise
-[proof diffs]: https://coq.inria.fr/distrib/current/refman/proofs/writing-proofs/proof-mode.html#coq:opt.Diffs
+[proof diffs]: https://coq.inria.fr/refman/proofs/writing-proofs/proof-mode.html#coq:opt.Diffs
 [Coquille]: https://github.com/the-lambda-church/coquille
 [YouCompleteMe]: https://github.com/ycm-core/YouCompleteMe/wiki/Building-Vim-from-source
 [universal-ctags]: https://github.com/universal-ctags/ctags

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -348,7 +348,7 @@ function! coqtail#start(...) abort
   if s:running()
     call coqtail#util#warn('Coq is already running.')
   else
-    let after_start_cmd = get(a:, 1, v:null)
+    let l:after_start_cmd = get(a:, 1, v:null)
 
     " See comment in coqtail#init() about buffer-local variables
     let b:coqtail_started = coqtail#init()
@@ -427,6 +427,8 @@ function! coqtail#start(...) abort
       let l:args = map(copy(l:proj_args + a:000), 'expand(v:val)')
     endif
 
+    let l:coqtail_version_str = b:coqtail_version.str_version
+
     " Callback to be run after Coqtop has launched.
     function! After_startCB(chan, msg) abort closure
       call s:unlock_buffer(a:msg.buf)
@@ -446,11 +448,11 @@ function! coqtail#start(...) abort
 
       call coqtail#refresh()
 
-      call s:init_proof_diffs(b:coqtail_version.str_version)
+      call s:init_proof_diffs(l:coqtail_version_str)
 
       " Call the after_start_cmd, if present
-      if after_start_cmd isnot v:null
-        execute after_start_cmd
+      if l:after_start_cmd isnot v:null
+        execute l:after_start_cmd
       endif
     endfunction
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -484,6 +484,9 @@ function! coqtail#stop() abort
   silent! autocmd! coqtail#Quit * <buffer>
   silent! autocmd! coqtail#Sync * <buffer>
 
+  " Clean up auxiliary panels
+  call coqtail#panels#cleanup()
+
   call s:call('stop', 'coqtail#cleanupCB', 1, {})
 endfunction
 
@@ -495,9 +498,6 @@ function! coqtail#cleanupCB(chan, msg) abort
   silent! call b:coqtail_chan.close()
   let b:coqtail_chan = 0
   let b:coqtail_started = 0
-
-  " Clean up auxiliary panels
-  call coqtail#panels#cleanup()
 endfunction
 
 " Advance/rewind Coq to the specified position.

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -488,7 +488,7 @@ function! coqtail#stop() abort
   " Set a 'coqtail_stopping' flag in order to prevent multiple stop signals or
   " interrupts from being sent, in particular when calling this while a
   " coqtail#start is ongoing
-  if !exists("b:coqtail_stopping") || !b:coqtail_stopping
+  if !exists('b:coqtail_stopping') || !b:coqtail_stopping
     let b:coqtail_stopping = 1
   else
     return

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -448,9 +448,9 @@ function! coqtail#after_startCB(chan, msg) abort
   call s:unlock_buffer(a:msg.buf)
 
   " l:buf is the number of the current buffer
-  let l:buf = bufnr('')
-  " Hack: switch to the buffer that is running this Coq instance
-  execute 'noautocmd keepalt buffer' a:msg.buf
+  let l:buf = bufnr('%')
+  " Switch to the buffer that is running this Coq instance
+  execute g:coqtail#util#bufchangepre 'buffer' a:msg.buf
 
   let l:ret_msg = a:msg.ret
   " l:ret_msg is [coqtail_error_message, coqtop_stderr]
@@ -474,8 +474,8 @@ function! coqtail#after_startCB(chan, msg) abort
     execute b:after_start_cmd
   endif
 
-  " Hack: switch back to the previous buffer
-  execute 'noautocmd keepalt buffer' l:buf
+  " Switch back to the previous buffer
+  execute g:coqtail#util#bufchangepre 'buffer' l:buf
 endfunction
 
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -126,7 +126,7 @@ endfunction
 
 " Patch the given filepath to refer to the source in case dune is used.
 function! s:patch_path_for_dune(path) abort
-  let l:patched = substitute(a:path, "/_build/default", "", "")
+  let l:patched = substitute(a:path, '/_build/default', '', '')
   return l:patched
 endfunction
 
@@ -334,13 +334,10 @@ function! coqtail#init() abort
   return 1
 endfunction
 
+" Search for a Dune project file.
 function! coqtail#locate_dune() abort
-  let l:file = findfile("dune-project", '.;')
-  if l:file !=# ''
-    return 1
-  else
-    return 0
-  endif
+  let l:file = findfile('dune-project', '.;')
+  return l:file !=# ''
 endfunction
 
 " Launch Coqtop and open the auxiliary panels.
@@ -376,7 +373,7 @@ function! coqtail#start(...) abort
     endif
 
     " Check if version is supported
-    " l:ver_or_msg[0] is
+    " l:ver_or_msg is
     " {version: [major, minor, patch], str_version: str, latest: str | None}
     let b:coqtail_version = l:ver_or_msg
     if b:coqtail_version.latest != v:null
@@ -393,23 +390,22 @@ function! coqtail#start(...) abort
       \ 'width': winwidth(l:info_winid),
       \ 'height': winheight(l:info_winid)})
 
-
     " Locate CoqProject and dune-project files
     let [b:coqtail_project_files, l:proj_args] = coqtail#coqproject#locate()
     let b:coqtail_in_dune_project = coqtail#locate_dune()
 
     " Determine which build system to use
-    if g:coqtail_build_system == 'prefer-dune'
+    if g:coqtail_build_system ==# 'prefer-dune'
       let b:coqtail_use_dune = b:coqtail_in_dune_project
-    elseif g:coqtail_build_system == 'prefer-coqproject'
+    elseif g:coqtail_build_system ==# 'prefer-coqproject'
       if b:coqtail_project_files == []
         let b:coqtail_use_dune = b:coqtail_in_dune_project
       else
         let b:coqtail_use_dune = 0
       endif
-    elseif g:coqtail_build_system == 'dune'
+    elseif g:coqtail_build_system ==# 'dune'
       let b:coqtail_use_dune = 1
-    elseif g:coqtail_build_system == 'coqproject'
+    elseif g:coqtail_build_system ==# 'coqproject'
       let b:coqtail_use_dune = 0
     else
       " invalid value
@@ -476,11 +472,10 @@ function! coqtail#after_startCB(chan, msg) abort
   " Call the after_start_cmd, if present
   if b:after_start_cmd != v:null
     execute b:after_start_cmd
-  endfor
+  endif
 
   " Hack: switch back to the previous buffer
   execute 'noautocmd keepalt buffer' l:buf
-
 endfunction
 
 

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -591,7 +591,7 @@ endfunction
 
 " Define Coqtail commands.
 function! coqtail#define_commands() abort
-  call s:cmddef('CoqStart', 'call coqtail#start(v:null, <f-args>)', '')
+  call s:cmddef('CoqStart', 'call coqtail#start(v:null, [<f-args>])', '')
   call s:cmddef('CoqStop', 'call coqtail#stop()', '')
   call s:cmddef('CoqInterrupt', 'call coqtail#interrupt()', '')
   call s:cmddef('CoqNext', 'call s:call("step", "", 0, {"steps": <count>})', 's')

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -335,7 +335,6 @@ function! coqtail#init() abort
 endfunction
 
 function! coqtail#locate_dune() abort
-  let l:files = []
   let l:file = findfile("dune-project", '.;')
   if l:file !=# ''
     return 1
@@ -364,7 +363,7 @@ function! coqtail#start(...) abort
       \ 'coq_path': expand(coqtail#util#getvar([b:, g:], 'coqtail_coq_path', $COQBIN)),
       \ 'coq_prog': coqtail#util#getvar([b:, g:], 'coqtail_coq_prog', '')})
     if !l:ok || type(l:ver_or_msg) == g:coqtail#compat#t_string
-    let l:msg = 'Failed to find Coq.'
+      let l:msg = 'Failed to find Coq.'
       if l:ok
         " l:ver_or_msg is coqtail_error_message
         let l:msg .= "\n" . l:ver_or_msg

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -53,7 +53,7 @@ function! s:init(name) abort
 
   " badd forces a new buffer to be created in case the main buffer is empty
   execute 'keepjumps badd ' . l:bufname . s:counter
-  execute 'silent keepjumps keepalt hide edit ' . l:bufname . s:counter
+  execute g:coqtail#util#bufchangepre . ' hide edit ' . l:bufname . s:counter
   setlocal buftype=nofile
   execute 'setlocal filetype=coq-' . l:name
   setlocal noswapfile
@@ -93,7 +93,7 @@ function! coqtail#panels#init() abort
   endfor
 
   " Switch back to main panel
-  execute 'silent keepjumps keepalt buffer ' . l:main_buf
+  execute g:coqtail#util#bufchangepre . ' buffer ' . l:main_buf
   call cursor(l:curpos)
 
   let s:counter += 1
@@ -160,7 +160,7 @@ function! s:open(panel, force) abort
           \ : l:dir ==# 'left' ? 'vertical leftabove'
           \ : l:dir ==# 'right' ? 'vertical rightbelow' : ''
         if l:dir !=# ''
-          execute printf('silent keepjumps keepalt %s sbuffer %d', l:dir, l:buf)
+          execute printf(g:coqtail#util#bufchangepre . ' %s sbuffer %d', l:dir, l:buf)
           clearjumps
           let b:coqtail_panel_open = 1
           let l:opened = l:buf

--- a/autoload/coqtail/util.vim
+++ b/autoload/coqtail/util.vim
@@ -1,6 +1,11 @@
 " Author: Wolf Honore
 " Utility functions.
 
+" A common prefix to silently switch buffers with commands like buffer, edit,
+" etc. Expected to be used as:
+" execute g:coqtail#util#bufchangepre 'buffer' l:buf
+let g:coqtail#util#bufchangepre = 'silent keepjumps keepalt'
+
 " Print a message with the specified highlighting.
 " NOTE: Without 'unsilent' messages triggered during autocmds don't display in
 " NeoVim because 'shortmess+=F' is set by default.

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -235,7 +235,7 @@ b:coqtail_timeout	The time in seconds before interrupting Coqtop after
 						      *g:coqtail_build_system*
 g:coqtail_build_system	The build system to use in order to determine
 			arguments passed to Coqtop. Can be `dune`, `coqproject`,
-			`prefer-dune`, `prefer-coqproject`.
+			`prefer-dune`, or `prefer-coqproject`.
 			The `dune` mode always uses `dune` for determining
 			arguments for Coqtop.
 			The `coqproject` mode always looks for Coq project
@@ -268,7 +268,8 @@ b:coqtail_use_dune	Whether to use dune for Coqtop options after
 			available options.
 
 						   *g:coqtail_dune_compile_deps*
-g:coqtail_dune_compile_deps When using dune, compile dependencies of this file
+g:coqtail_dune_compile_deps
+			When using dune, compile dependencies of this file
 			before launching Coqtop.
 
 			Default: 0

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -232,16 +232,46 @@ b:coqtail_timeout	The time in seconds before interrupting Coqtop after
 
 			Default: 0
 
+						      *g:coqtail_build_system*
+g:coqtail_build_system	The build system to use in order to determine
+			arguments passed to Coqtop. Can be `dune`, `coqproject`,
+			`prefer-dune`, `prefer-coqproject`.
+			The `dune` mode always uses `dune` for determining
+			arguments for Coqtop.
+			The `coqproject` mode always looks for Coq project
+			files.
+			The `prefer-dune` mode will use dune if a
+			`dune-project` file can be located and otherwise fall
+			back to `coqproject` mode.
+			The `prefer-coqproject` mode will use Coq project
+			files if any are found, or try to fall back to `dune`
+			if none are found.
+
+			Default: 'prefer-dune'
+
 				     *g:coqtail_project_names* *coq-project-files*
-g:coqtail_project_names	The names of Coq project files to search for. The
-			search begins in the current directory and proceeds
-			upwards. If found, project files are parsed and passed
-			as arguments to Coqtop by `:CoqStart`.
+g:coqtail_project_names	The names of Coq project files to search for in Coq
+			project mode. The search begins in the current
+			directory and proceeds upwards. If found, project
+			files are parsed and passed as arguments to Coqtop
+			by `:CoqStart`.
 
 			Default: ['_CoqProject']
 
 						       *b:coqtail_project_files*
 b:coqtail_project_files	Paths to the Coq project files found during `:CoqStart`.
+
+
+							   *b:coqtail_use_dune*
+b:coqtail_use_dune	Whether to use dune for Coqtop options after
+			`g:coqtail_build_system` has been evaluated with the
+			available options.
+
+						   *g:coqtail_dune_compile_deps*
+g:coqtail_dune_compile_deps When using dune, compile dependencies of this file
+			before launching Coqtop.
+
+			Default: 0
 
 				   *g:coqtail_map_prefix* *coqtail-mapping-prefix*
 g:coqtail_map_prefix	The character(s) to begin Coqtail mappings.

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -162,7 +162,7 @@ class Coqtail:
         goal_msg - Lines of text to display in the goal panel
         goal_hls - Highlight positions for each line of goal_msg
         """
-        self.coqtop = CT.Coqtop()
+        self.coqtop = CT.Coqtop(self.add_info_callback)
         self.handler = handler
         self.changedtick = 0
         self.buffer: List[bytes] = []
@@ -703,6 +703,11 @@ class Coqtail:
             self.goal_msg, self.goal_hls = msg
         if clear or "".join(self.goal_msg) == "":
             self.goal_msg, self.goal_hls = ["No goals."], []
+
+    def add_info_callback(self, msg: str) -> None:
+        """Callback for appending to the info panel and refreshing it."""
+        self.set_info([msg], reset=False)
+        self.handler.refresh(goals=False, force=True, scroll=True)
 
     def set_info(
         self,

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -213,7 +213,7 @@ class Coqtail:
     # Coqtop Interface #
     def start(
         self,
-        coqproject_args: Iterable[str],
+        coqproject_args: List[str],
         use_dune: bool,
         dune_compile_deps: bool,
         opts: VimOptions,

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -197,7 +197,7 @@ class Coqtail:
         coq_path: str,
         coq_prog: str,
         opts: VimOptions,
-    ) -> Union[VersionInfo, str]:
+    ) -> Union[CT.VersionInfo, str]:
         # pylint: disable=unused-argument
         # opts is always passed by handle().
         """Find the Coqtop executable."""

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -200,7 +200,7 @@ class Coqtail:
     ) -> Any:
         # pylint: disable=unused-argument
         # opts is always passed by handle().
-        """Start a new Coqtop instance."""
+        """Find the Coqtop executable."""
         try:
             ver_or_err = self.coqtop.find_coq(
                 coq_path if coq_path != "" else None,

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -886,7 +886,7 @@ class CoqtailHandler(StreamRequestHandler):
             try:
                 msg = self.rfile.readline()
                 msg_id, data = json.loads(msg)
-            except (json.JSONDecodeError, ConnectionError):
+            except (json.JSONDecodeError, ConnectionError, ValueError):
                 # Check if channel closed
                 self.closed = True
                 break

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -706,7 +706,7 @@ class Coqtail:
 
     def add_info_callback(self, msg: str) -> None:
         """Callback for appending to the info panel and refreshing it."""
-        self.set_info([msg], reset=False)
+        self.set_info(msg.split("\n"), reset=False)
         self.handler.refresh(goals=False, force=True, scroll=True)
 
     def set_info(

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -197,7 +197,9 @@ class Coqtail:
         self,
         coq_path: str,
         coq_prog: str,
-        args: Iterable[str],
+        coqproject_args: Iterable[str],
+        use_dune: bool,
+        dune_compile_deps: bool,
         opts: VimOptions,
     ) -> Tuple[Union[CT.VersionInfo, str], str]:
         """Start a new Coqtop instance."""
@@ -206,7 +208,9 @@ class Coqtail:
                 coq_path if coq_path != "" else None,
                 coq_prog if coq_prog != "" else None,
                 opts["filename"],
-                args,
+                coqproject_args,
+                use_dune,
+                dune_compile_deps,
                 timeout=opts["timeout"],
                 stderr_is_warning=opts["stderr_is_warning"],
             )

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -197,7 +197,7 @@ class Coqtail:
         coq_path: str,
         coq_prog: str,
         opts: VimOptions,
-    ) -> Any:
+    ) -> Union[VersionInfo, str]:
         # pylint: disable=unused-argument
         # opts is always passed by handle().
         """Find the Coqtop executable."""

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -100,35 +100,36 @@ class Coqtop:
         self.logger.addHandler(self.handler)
         self.logger.setLevel(logging.INFO)
 
-    def get_dune_args(self,
-                      filename: str) -> str:
-      if self.xml.valid_module(filename):
-        # dune needs relative paths to work properly
-        basename = os.path.basename(filename)
-        filepath = os.path.dirname(filename)
+    def get_dune_args(self, filename: str) -> str:
+        if self.xml.valid_module(filename):
+            # dune needs relative paths to work properly
+            basename = os.path.basename(filename)
+            filepath = os.path.dirname(filename)
 
-        # check if the file is located in a dune project
-        self.logger.debug(("query dune in ", filepath))
-        dune_check = ("dune", "show", "workspace")
-        dune_check_result = subprocess.run(dune_check, cwd=filepath)
-        if dune_check_result.returncode != 0:
-          self.logger.debug("no dune project found")
-          return []
+            # check if the file is located in a dune project
+            self.logger.debug(("query dune in ", filepath))
+            dune_check = ("dune", "show", "workspace")
+            dune_check_result = subprocess.run(dune_check, cwd=filepath)
+            if dune_check_result.returncode != 0:
+                self.logger.debug("no dune project found")
+                return []
 
-        dune_launch = ("dune", "coq", "top", basename, "--toplevel", "echo")
-        self.logger.debug(dune_launch)
+            dune_launch = ("dune", "coq", "top", basename, "--toplevel", "echo")
+            self.logger.debug(dune_launch)
 
-        # run in `filepath` so that this also works if vim was not launched in a dune project directory
-        dune_result = subprocess.run(dune_launch, capture_output=True, cwd=filepath)
-        if dune_result.returncode == 0:
-          self.logger.debug("dune result")
-          args = dune_result.stdout.decode('utf-8')
-          self.logger.debug(args)
-          return args.split()
+            # run in `filepath` so that this also works if vim was not launched in a dune project directory
+            dune_result = subprocess.run(dune_launch, capture_output=True, cwd=filepath)
+            if dune_result.returncode == 0:
+                self.logger.debug("dune result")
+                args = dune_result.stdout.decode("utf-8")
+                self.logger.debug(args)
+                return args.split()
+            else:
+                self.logger.debug("dune error")
+                self.logger.debug(dune_result.stderr)
+                return []
         else:
-          self.logger.debug("dune error")
-          self.logger.debug(dune_result.stderr)
-          return []
+            return []
 
     # Coqtop Interface #
     def start(
@@ -143,14 +144,13 @@ class Coqtop:
         """Launch the Coqtop process."""
         assert self.coqtop is None
 
-
         try:
             self.logger.debug("start")
             self.xml, latest = XMLInterface(coq_path, coq_prog)
 
             # if we did not get any arguments from _CoqProject, try to use dune
             if len(args) == 0:
-              args = self.get_dune_args(filename)
+                args = self.get_dune_args(filename)
 
             launch = self.xml.launch(filename, args)
             self.logger.debug(launch)

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -256,7 +256,8 @@ class Coqtop:
 
             args = coqproject_args
             if use_dune and self.is_in_valid_dune_project(filename):
-                args += self.get_dune_args(filename, dune_compile_deps)
+                # Add user-provided args last so they take precedence.
+                args = self.get_dune_args(filename, dune_compile_deps) + args
 
             launch = self.xml.launch(filename, args)
             self.logger.debug(launch)

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -106,7 +106,7 @@ class Coqtop:
 
     def is_in_valid_dune_project(self, filename: str) -> bool:
         """Query dune to assert that the given file is in a correctly configured dune project."""
-        if self.xml.valid_module(filename):
+        if self.xml is not None and self.xml.valid_module(filename):
             # dune needs relative paths to work properly
             filepath = os.path.dirname(filename)
 
@@ -132,9 +132,11 @@ class Coqtop:
         basename = os.path.basename(filename)
         filepath = os.path.dirname(filename)
 
-        dune_launch = ("dune", "coq", "top", basename, "--toplevel", "echo")
+        dune_launch_base = ("dune", "coq", "top", basename, "--toplevel", "echo")
         if not dune_compile_deps:
-            dune_launch += ("--no-build",)
+            dune_launch = dune_launch_base + ("--no-build",)
+        else:
+            dune_launch = dune_launch_base + ("",)
         self.logger.debug(dune_launch)
 
         # run in `filepath` so that this also works if vim was not launched in a dune project directory

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -846,9 +846,7 @@ class Coqtop:
             self.dune.send_signal(signal.SIGTERM)
             self.dune.wait()
             self.dune = None
-        else:
-            if self.coqtop is None:
-                raise CoqtopError("Coqtop is not running.")
+        elif self.coqtop is not None:
             self.coqtop.send_signal(signal.SIGINT)
 
     # Current State #

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -309,6 +309,9 @@ class Coqtop:
 
     def stop(self) -> None:
         """End the Coqtop process."""
+        if self.dune is not None:
+            self.interrupt()
+
         if self.coqtop is not None:
             self.logger.debug("stop")
             self.stopping = True
@@ -841,6 +844,8 @@ class Coqtop:
         if self.dune is not None:
             # if dune is running, stop it
             self.dune.send_signal(signal.SIGTERM)
+            self.dune.wait()
+            self.dune = None
         else:
             if self.coqtop is None:
                 raise CoqtopError("Coqtop is not running.")

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -3,9 +3,9 @@
 """Coqtop interface with functions to send commands and parse responses."""
 
 import datetime
+import io
 import logging
 import os
-import io
 import signal
 import subprocess
 import threading
@@ -18,12 +18,12 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
+    Callable,
     Generator,
     Iterable,
     Iterator,
     List,
     Mapping,
-    Callable,
     Optional,
     Tuple,
     Union,

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -8,6 +8,7 @@ import signal
 import subprocess
 import threading
 import time
+import os
 from concurrent import futures
 from contextlib import contextmanager
 from queue import Empty, Queue
@@ -99,6 +100,36 @@ class Coqtop:
         self.logger.addHandler(self.handler)
         self.logger.setLevel(logging.INFO)
 
+    def get_dune_args(self,
+                      filename: str) -> str:
+      if self.xml.valid_module(filename):
+        # dune needs relative paths to work properly
+        basename = os.path.basename(filename)
+        filepath = os.path.dirname(filename)
+
+        # check if the file is located in a dune project
+        self.logger.debug(("query dune in ", filepath))
+        dune_check = ("dune", "show", "workspace")
+        dune_check_result = subprocess.run(dune_check, cwd=filepath)
+        if dune_check_result.returncode != 0:
+          self.logger.debug("no dune project found")
+          return []
+
+        dune_launch = ("dune", "coq", "top", basename, "--toplevel", "echo")
+        self.logger.debug(dune_launch)
+
+        # run in `filepath` so that this also works if vim was not launched in a dune project directory
+        dune_result = subprocess.run(dune_launch, capture_output=True, cwd=filepath)
+        if dune_result.returncode == 0:
+          self.logger.debug("dune result")
+          args = dune_result.stdout.decode('utf-8')
+          self.logger.debug(args)
+          return args.split()
+        else:
+          self.logger.debug("dune error")
+          self.logger.debug(dune_result.stderr)
+          return []
+
     # Coqtop Interface #
     def start(
         self,
@@ -112,9 +143,15 @@ class Coqtop:
         """Launch the Coqtop process."""
         assert self.coqtop is None
 
+
         try:
             self.logger.debug("start")
             self.xml, latest = XMLInterface(coq_path, coq_prog)
+
+            # if we did not get any arguments from _CoqProject, try to use dune
+            if len(args) == 0:
+              args = self.get_dune_args(filename)
+
             launch = self.xml.launch(filename, args)
             self.logger.debug(launch)
             self.coqtop = subprocess.Popen(  # pylint: disable=consider-using-with

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -82,7 +82,8 @@ class Coqtop:
     """Provide an interface to the background Coqtop process."""
 
     def __init__(
-        self, add_info_callback: Optional[Callable[[str], None]] = None
+        self,
+        add_info_callback: Optional[Callable[[str], None]] = None,
     ) -> None:
         """Initialize Coqtop state.
 
@@ -123,7 +124,10 @@ class Coqtop:
             dune_check = ("dune", "describe", "workspace")
             try:
                 subprocess.run(
-                    dune_check, capture_output=True, cwd=filepath, check=True
+                    dune_check,
+                    capture_output=True,
+                    cwd=filepath,
+                    check=True,
                 )
             except subprocess.CalledProcessError as e:
                 self.logger.debug("file is not in correctly configured dune project")
@@ -139,7 +143,7 @@ class Coqtop:
         basename = os.path.basename(filename)
         filepath = os.path.dirname(filename)
 
-        dune_launch_base = (
+        dune_launch = (
             "dune",
             "coq",
             "top",
@@ -147,11 +151,8 @@ class Coqtop:
             "--toplevel",
             "echo",
             "--display=short",
+            "--no-build" if not dune_compile_deps else "",
         )
-        if not dune_compile_deps:
-            dune_launch = dune_launch_base + ("--no-build",)
-        else:
-            dune_launch = dune_launch_base + ("",)
         self.logger.debug(dune_launch)
 
         with subprocess.Popen(

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -112,6 +112,7 @@ class Coqtop:
         self.logger = logging.getLogger(str(id(self)))
         self.logger.addHandler(self.handler)
         self.logger.setLevel(logging.INFO)
+        self.toggle_debug()
 
     def is_in_valid_dune_project(self, filename: str) -> bool:
         """Query dune to assert that the given file is in a correctly configured dune project."""
@@ -136,7 +137,7 @@ class Coqtop:
             return True
         return False
 
-    def get_dune_args(self, filename: str, dune_compile_deps: bool) -> Iterable[str]:
+    def get_dune_args(self, filename: str, dune_compile_deps: bool) -> List[str]:
         """Get the arguments to pass to the coqtop process from dune.
         Assumes that the file is part of a correctly configured dune project."""
         # dune needs relative paths to work properly
@@ -240,7 +241,7 @@ class Coqtop:
     def start(
         self,
         filename: str,
-        coqproject_args: Iterable[str],
+        coqproject_args: List[str],
         use_dune: bool,
         dune_compile_deps: bool,
         timeout: Optional[int] = None,
@@ -253,10 +254,9 @@ class Coqtop:
         try:
             self.logger.debug("start")
 
+            args = coqproject_args
             if use_dune and self.is_in_valid_dune_project(filename):
-                args = self.get_dune_args(filename, dune_compile_deps)
-            else:
-                args = coqproject_args
+                args += self.get_dune_args(filename, dune_compile_deps)
 
             launch = self.xml.launch(filename, args)
             self.logger.debug(launch)

--- a/tests/coq/test_coqtop.py
+++ b/tests/coq/test_coqtop.py
@@ -26,10 +26,14 @@ def coq() -> Generator[Coqtop, None, None]:
     """Return a Coqtop for each version."""
     ct = Coqtop()
     coqbin = os.getenv("COQBIN")
-    ver_or_err, _ = ct.start(coqbin, None, "", [], False, False)
+    ver_or_err = ct.find_coq(coqbin, None)
     if isinstance(ver_or_err, dict):
-        yield ct
-        ct.stop()
+        res, _ = ct.start("", [], False, False)
+        if res is not None:
+            pytest.fail(f"Failed to create Coqtop instance\n{res}")
+        else:
+            yield ct
+            ct.stop()
     else:
         pytest.fail(f"Failed to create Coqtop instance\n{ver_or_err}")
 
@@ -265,7 +269,9 @@ def test_recognize_not_query(coq: Coqtop) -> None:
 def test_start_invalid_option() -> None:
     """Passing an invalid option on startup fails gracefully."""
     ct = Coqtop()
-    res, stderr = ct.start(None, None, "", ["--fake"], False, False)
+    res = ct.find_coq(None, None)
+    assert isinstance(res, dict)
+    res, stderr = ct.start("", ["--fake"], False, False)
     assert isinstance(res, str)
     assert stderr == ""
 
@@ -284,9 +290,11 @@ def test_start_invalid_option() -> None:
 def test_start_warning(args: List[str]) -> None:
     """Warnings do not cause startup to fail."""
     ct = Coqtop()
-    res, stderr = ct.start(None, None, "", args, False, False)
+    res = ct.find_coq(None, None)
     assert isinstance(res, dict)
     assert ct.xml is not None
+    res, stderr = ct.start("", args, False, False)
+    assert res is None
     # Some versions of Coq don't print warnings in the expected format.
     if ct.xml.warnings_wf and stderr != "":
         assert stderr.startswith("Warning:")
@@ -304,7 +312,9 @@ def test_start_invalid_xml(fake_interface: MagicMock) -> None:
     fake_xml.init.return_value = ("Init", b"<bad_xml></bad_xml>")
     fake_interface.return_value = (fake_xml, "")
     ct = Coqtop()
-    res, stderr = ct.start(None, None, "", [], False, False)
+    res = ct.find_coq(None, None)
+    assert isinstance(res, dict)
+    res, stderr = ct.start("", [], False, False)
     assert isinstance(res, str)
     assert stderr != ""
 
@@ -315,8 +325,10 @@ def test_start_noinit() -> None:
     if xml.version < (8, 5, 0):
         pytest.skip("Only 8.5+ supports -noinit")
     ct = Coqtop()
-    res, _ = ct.start(None, None, "", ["-noinit"], False, False)
+    res = ct.find_coq(None, None)
     assert isinstance(res, dict)
     assert ct.xml is not None
+    res, _ = ct.start("", ["-noinit"], False, False)
+    assert res is None
     succ, _, _, _ = ct.dispatch("Set Implicit Arguments.")
     assert succ

--- a/tests/coq/test_coqtop.py
+++ b/tests/coq/test_coqtop.py
@@ -26,7 +26,7 @@ def coq() -> Generator[Coqtop, None, None]:
     """Return a Coqtop for each version."""
     ct = Coqtop()
     coqbin = os.getenv("COQBIN")
-    ver_or_err, _ = ct.start(coqbin, None, "", [])
+    ver_or_err, _ = ct.start(coqbin, None, "", [], False, False)
     if isinstance(ver_or_err, dict):
         yield ct
         ct.stop()
@@ -265,7 +265,7 @@ def test_recognize_not_query(coq: Coqtop) -> None:
 def test_start_invalid_option() -> None:
     """Passing an invalid option on startup fails gracefully."""
     ct = Coqtop()
-    res, stderr = ct.start(None, None, "", ["--fake"])
+    res, stderr = ct.start(None, None, "", ["--fake"], False, False)
     assert isinstance(res, str)
     assert stderr == ""
 
@@ -284,7 +284,7 @@ def test_start_invalid_option() -> None:
 def test_start_warning(args: List[str]) -> None:
     """Warnings do not cause startup to fail."""
     ct = Coqtop()
-    res, stderr = ct.start(None, None, "", args)
+    res, stderr = ct.start(None, None, "", args, False, False)
     assert isinstance(res, dict)
     assert ct.xml is not None
     # Some versions of Coq don't print warnings in the expected format.
@@ -304,7 +304,7 @@ def test_start_invalid_xml(fake_interface: MagicMock) -> None:
     fake_xml.init.return_value = ("Init", b"<bad_xml></bad_xml>")
     fake_interface.return_value = (fake_xml, "")
     ct = Coqtop()
-    res, stderr = ct.start(None, None, "", [])
+    res, stderr = ct.start(None, None, "", [], False, False)
     assert isinstance(res, str)
     assert stderr != ""
 
@@ -315,7 +315,7 @@ def test_start_noinit() -> None:
     if xml.version < (8, 5, 0):
         pytest.skip("Only 8.5+ supports -noinit")
     ct = Coqtop()
-    res, _ = ct.start(None, None, "", ["-noinit"])
+    res, _ = ct.start(None, None, "", ["-noinit"], False, False)
     assert isinstance(res, dict)
     assert ct.xml is not None
     succ, _, _, _ = ct.dispatch("Set Implicit Arguments.")


### PR DESCRIPTION
This adds better support for dune, see #344. 

Current caveats: 
- This blocks when dune needs to compile dependencies. Potentially we could make calling `start` non-blocking?
- If you create a new unsaved buffer with dependencies from your current project, you will have to save first before starting Coqtail, as otherwise it won't find the dependencies. (this is something which works when using _CoqProject, I think, but isn't a very common occurrence)
- This should have better error reporting. E.g. report that this is a dune project, but dune does not know how to build the file, etc.

For making `CoqStart` non-blocking, I don't really have any idea how to implement that, but it would be pretty nice to have (or even just emit a message that dependencies are being compiled). 
Alternatively, we could also pass `--no-build` to dune, which skips building the dependencies. That would mirror the current behavior for `_CoqProject`.

Maybe there should also be a configuration option to enable/disable calling `dune` at all?