### PR TITLE
Adapt to new error location type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased ([main])
 
 ### Added
+- Preliminary support for Coq 8.20 by adapting to the new type used to report
+  error locations.
+  (PR #358)
 - `g:coqtail_treat_stderr_as_warning` option to ignore unrecognized warnings on stderr.
   (PR #338)
 - Add a hook for more flexible keybindings.

--- a/tests/coq/test_coqtop.py
+++ b/tests/coq/test_coqtop.py
@@ -166,15 +166,33 @@ def test_goals_no_change(coq: Coqtop) -> None:
 def test_advance_fail(coq: Coqtop) -> None:
     """If advance fails then the state will not change."""
     old_state = get_state(coq)
-    fail, _, _, _ = coq.dispatch("SyntaxError")
-    assert not fail
+    succ, _, _, _ = coq.dispatch("SyntaxError.")
+    assert not succ
     assert old_state == get_state(coq)
     succ, _, _, _ = coq.dispatch("Lemma x : False.")
     assert succ
     old_state = get_state(coq)
-    fail, _, _, _ = coq.dispatch("reflexivity.")
-    assert not fail
+    succ, _, _, _ = coq.dispatch("reflexivity.")
+    assert not succ
     assert old_state == get_state(coq)
+
+
+def test_advance_fail_err_loc(coq: Coqtop) -> None:
+    """If advance fails then the error locations are correct."""
+    assert coq.xml is not None
+    succ, _, err_loc, _ = coq.dispatch("SyntaxError.")
+    assert not succ
+    assert err_loc is not None
+    if coq.xml.version < (8, 5, 0):
+        assert err_loc == (-1, -1)
+    elif (8, 5, 0) <= coq.xml.version < (8, 6, 0):
+        assert err_loc == (0, 12)
+    else:
+        assert err_loc == (0, 11)
+    succ, _, err_loc, _ = coq.dispatch("Definition α := not_defined.")
+    assert not succ
+    assert err_loc is not None
+    assert err_loc == (17, 28)
 
 
 # TODO: move interrupt tests to a separate file


### PR DESCRIPTION
https://github.com/coq/coq/pull/19040 changes the way error locations are reported in the XML protocol. Specifically, it replaces the `loc_s` and `loc_e` attributes of the `fail` result with an optional `Loc.t` field. If I understand correctly, the `start` and `stop` fields contain the same byte offsets as the old `loc_s` and `loc_e`, so it's enough to just extract and return those.