### PR TITLE
Fix local nix + coq tests

### DIFF
--- a/tests/coq/test_coqtop.py
+++ b/tests/coq/test_coqtop.py
@@ -3,6 +3,7 @@
 # pylint: disable=redefined-outer-name
 """Coq integration tests."""
 
+import os
 from typing import Generator, List, Tuple
 from unittest.mock import MagicMock, patch
 
@@ -24,7 +25,8 @@ def get_state(coq: Coqtop) -> Tuple[int, int, List[int]]:
 def coq() -> Generator[Coqtop, None, None]:
     """Return a Coqtop for each version."""
     ct = Coqtop()
-    ver_or_err, _ = ct.start(None, None, "", [])
+    coqbin = os.getenv("COQBIN")
+    ver_or_err, _ = ct.start(coqbin, None, "", [])
     if isinstance(ver_or_err, dict):
         yield ct
         ct.stop()

--- a/tox.ini
+++ b/tox.ini
@@ -18,10 +18,11 @@ commands = python -m pytest -q tests/unit {posargs}
 description = Coq integration tests
 setenv =
     {[pybase]setenv}
-    !coq: PATH = {envtmpdir}/coq/bin{:}{env:PATH}
+    !coq: COQBIN = {envtmpdir}/coq/bin
 passenv =
-    NIX_PATH
+    COQBIN
     HOME
+    NIX_PATH
 deps = {[pybase]deps}
 allowlist_externals =
     !coq: nix-build


### PR DESCRIPTION
`tox -e coqXX-py36` is supposed to use Nix to run the Coq tests locally with version `XX`, but at some point, this was broken by changing how Coqtail locates Coq executables. The CI didn't catch it because it uses `tox -e coq-py36`, which just uses whatever version is currently installed.

The solution is to have the test harness pass the `COQBIN` environment variable to Coqtop.start.