### PR TITLE
Fix NeoVim Deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased ([main])
 
+### Fixed
+- A deadlock in NeoVim when executing certain commands before `:CoqStart`.
+  (PR #361)
+
 ## [1.7.2]
 
 ### Added

--- a/autoload/coqtail/channel.vim
+++ b/autoload/coqtail/channel.vim
@@ -116,6 +116,8 @@ elseif g:coqtail#compat#nvim
         if has_key(s:replies, l:msg_id)
           let s:replies[l:msg_id] = l:data
         elseif has_key(s:callbacks, l:msg_id)
+          " This will deadlock if the callback calls `s:evalexpr` since
+          " `s:chanrecv` can only handle one message at a time.
           call call(s:callbacks[l:msg_id], [a:handle, l:data])
           unlet s:callbacks[l:msg_id]
         endif

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -827,10 +827,8 @@ class Coqtail:
         log = self.coqtop.toggle_debug()
         if log is None:
             msg = "Debugging disabled."
-            self.log = ""
         else:
             msg = f"Debugging enabled. Log: {log}."
-            self.log = log
 
         self.set_info(msg, reset=True)
         self.refresh(goals=False, opts=opts)

--- a/python/coqtop.py
+++ b/python/coqtop.py
@@ -112,7 +112,6 @@ class Coqtop:
         self.logger = logging.getLogger(str(id(self)))
         self.logger.addHandler(self.handler)
         self.logger.setLevel(logging.INFO)
-        self.toggle_debug()
 
     def is_in_valid_dune_project(self, filename: str) -> bool:
         """Query dune to assert that the given file is in a correctly configured dune project."""

--- a/python/xmlInterface.py
+++ b/python/xmlInterface.py
@@ -798,9 +798,9 @@ class XMLInterface84(XMLInterfaceBase):
                 "goal": self._to_goal,
                 "goals": self._to_goals,
                 "evar": self._to_evar,
-                "option_value": self._to_option_value,
+                "option_value": self._to_option_value,  # type: ignore
                 "option_state": self._to_option_state,
-                "status": self._to_status,
+                "status": self._to_status,  # type: ignore
                 "coq_info": self._to_coq_info,
                 "message": self._to_message,
                 "feedback": self._to_feedback,
@@ -1156,10 +1156,10 @@ class XMLInterface85(XMLInterfaceBase):
                 "goal": self._to_goal,
                 "goals": self._to_goals,
                 "evar": self._to_evar,
-                "option_value": self._to_option_value,
+                "option_value": self._to_option_value,  # type: ignore
                 "option_state": self._to_option_state,
                 "state_id": self._to_state_id,
-                "status": self._to_status,
+                "status": self._to_status,  # type: ignore
                 "coq_info": self._to_coq_info,
                 "message": self._to_message,
                 "feedback": self._to_feedback,


### PR DESCRIPTION
Calling `:CoqJumpToEnd` before `:CoqStart` results in a deadlock on NeoVim. The sequence of events is:
1. Since `!s:running()`, `:CoqJumpToEnd` calls `coqtail#start` with `coqtail#jumpto("endpoint")` as a callback.
2. `coqtail#start` calls `s:call`, which calls `s:sendexpr` and registers `coqtail#after_startCB` as its callback.
3. `s:chanrecv` receives the reply and executes `coqtail#after_startCB`.
4. `coqtail#after_startCB` executes `coqtail#jumpto`, which calls `s:call`, which calls `s:evalexpr`.
5. `s:evalexpr` blocks while waiting for a reply, but `s:chanrecv` is also blocked waiting for `coqtail#after_startCB` to return.

Commands like `:CoqNext` don't have this problem because they execute asynchronously, so `coqtail#after_startCB` calls `s:sendexpr` instead of `s:evalexpr`. It also works fine on Vim because it uses the builtin `ch_evalexpr`, which handles other messages while waiting for a reply.

The ideal solution would be to somehow execute callbacks asynchronously, but I couldn't figure out a way of doing that in vimscript. Perhaps it's possible with Lua. In any case, I realized that the only synchronous commands that could be called before `:CoqStart` are `:CoqJumpToEnd`, `:CoqJumpToError`, and `:CoqGotoDef`, so I just have these cases busy wait for `coqtail#start` to complete instead of using callbacks.

Fixes #360.