### PR TITLE
Pass function instead of string to `coqtail#start`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased ([main])
 
 ### Fixed
+- Correctly execute commands containing quotes (e.g., `Coq Check a'`).
+  (PR #371)
 - Avoid a race condition when calling commands before Coqtail is fully initialized.
   (PR #366)
 - A deadlock in NeoVim when executing certain commands before `:CoqStart`.


### PR DESCRIPTION
Most commands (`CoqNext`, `CoqUndo`, etc) are defined to first call `coqtail#start` if necessary and pass a command to run after it completes. Previously, this was done with a string that's run with `execute b:after_start_cmd`. However, passing the command as a string to `coqtail#start` is problematic when the command itself contains quotes, such as `Coq Check a'` (see #369).

The solution implemented here is to pass a function (technically a `funcref`) to `coqtail#start` instead, which avoids the problem. This should not change the behavior at all except to fix the issue with quotes in command arguments.

Fixes #369.