### PR TITLE
Fix `Set Default Proof Mode` being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   (PR #373)
 
 ### Fixed
+- Handle `Set Default Proof Mode` correctly in Coq >= 8.18 by using `Add`
+  instead of `SetOptions`.
+  (PR #377)
 - Correctly execute commands containing quotes (e.g., `Coq Check a'`).
   (PR #371)
 - Avoid a race condition when calling commands before Coqtail is fully initialized.


### PR DESCRIPTION
Due to a change in how Coq parses vernacular commands (https://github.com/coq/coq/commit/40373610d6024510125405f53293809bc850b3af#diff-66d601f10f9baccbf2b788a65d749b194c0b828dab399f69c216da8e63100303R65), certain options, including `Default Proof Mode` cannot be set by `SetOptions` in Coq >=8.18. The solution is just to use `Add` instead. Unfortunately, Coq complains about setting certain options like `Printing All` this way, so these few cases still use `SetOptions`.

Fix #375.