### PR TITLE
Concealing special characters

### DIFF
--- a/syntax/coq-goals.vim
+++ b/syntax/coq-goals.vim
@@ -49,10 +49,15 @@ syn cluster coqTerm            contains=coqKwd,coqTermPunctuation,coqKwdMatch,co
 syn region coqKwdMatch         contained contains=@coqTerm matchgroup=coqKwd start="\<match\>" end="\<with\>"
 syn region coqKwdLet           contained contains=@coqTerm matchgroup=coqKwd start="\<let\>"   end=":="
 syn region coqKwdParen         contained contains=@coqTerm matchgroup=coqTermPunctuation start="(" end=")" keepend extend
-syn keyword coqKwd             contained else end exists2 fix forall fun if in struct then as return
+syn keyword coqKwd             contained else end exists2 fix if in struct then as return
+syn keyword coqKwd             contained forall conceal cchar=∀
+syn keyword coqKwd             contained fun conceal cchar=λ
+syn match coqKwd               contained /\/\\/ conceal cchar=∧
+syn match coqKwd               contained /\\\// conceal cchar=∨
+syn match   coqKwd             contained "\~" conceal cchar=¬
 syn match   coqKwd             contained "\<where\>"
-syn match   coqKwd             contained "\<exists!\?\>"
-syn match   coqKwd             contained "|\|/\\\|\\/\|<->\|\~\|->\|=>\|{\|}\|&\|+\|-\|*\|=\|>\|<\|<="
+syn match   coqKwd             contained "\<exists!\?\>" conceal cchar=∃
+syn match   coqKwd             contained "|\|<->\|->\|=>\|{\|}\|&\|+\|-\|*\|=\|>\|<\|<="
 syn match coqTermPunctuation   contained ":=\|:>\|:\|;\|,\|||\|\[\|\]\|@\|?\|\<_\>"
 
 " Various (High priority)

--- a/syntax/coq-infos.vim
+++ b/syntax/coq-infos.vim
@@ -63,10 +63,15 @@ syn cluster coqTerm            contains=coqKwd,coqTermPunctuation,coqKwdMatch,co
 syn region coqKwdMatch         contained contains=@coqTerm matchgroup=coqKwd start="\<match\>" end="\<with\>"
 syn region coqKwdLet           contained contains=@coqTerm matchgroup=coqKwd start="\<let\>"   end=":="
 syn region coqKwdParen         contained contains=@coqTerm matchgroup=coqTermPunctuation start="(" end=")" keepend extend
-syn keyword coqKwd             contained else end exists2 fix forall fun if in struct then as return
+syn keyword coqKwd             contained else end exists2 fix if in struct then as return
+syn keyword coqKwd             contained forall conceal cchar=∀
+syn keyword coqKwd             contained fun conceal cchar=λ
+syn match coqKwd               contained /\/\\/ conceal cchar=∧
+syn match coqKwd               contained /\\\// conceal cchar=∨
+syn match   coqKwd             contained "\~" conceal cchar=¬
 syn match   coqKwd             contained "\<where\>"
-syn match   coqKwd             contained "\<exists!\?\>"
-syn match   coqKwd             contained "|\|/\\\|\\/\|<->\|\~\|->\|=>\|{\|}\|&\|+\|-\|*\|=\|>\|<\|<="
+syn match   coqKwd             contained "\<exists!\?\>" conceal cchar=∃
+syn match   coqKwd             contained "|\|<->\|->\|=>\|{\|}\|&\|+\|-\|*\|=\|>\|<\|<="
 syn match coqTermPunctuation   contained ":=\|:>\|:\|;\|,\|||\|\[\|\]\|@\|?\|\<_\>"
 
 " Sections

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -107,11 +107,19 @@ syn cluster coqTerm            contains=coqKwd,coqTermPunctuation,coqKwdMatch,co
 syn region coqKwdMatch         contained contains=@coqTerm matchgroup=coqKwd start="\<match\>" end="\<with\>"
 syn region coqKwdLet           contained contains=@coqTerm matchgroup=coqKwd start="\<let\>"   end=":="
 syn region coqKwdParen         contained contains=@coqTerm matchgroup=coqTermPunctuation start="(" end=")" keepend extend
-syn keyword coqKwd             contained else end exists2 fix cofix forall fun if in struct then as return
+syn keyword coqKwd             contained else end exists2 fix cofix if in struct then as return
+syn keyword coqKwd             contained forall conceal cchar=∀
+syn keyword coqKwd             contained fun conceal cchar=λ
+syn match coqKwd               contained /\/\\/ conceal cchar=∧
+syn match coqKwd               contained /\\\// conceal cchar=∨
+syn match   coqKwd             contained "\~" conceal cchar=¬
 syn match   coqKwd             contained "\<where\>"
-syn match   coqKwd             contained "\<exists!\?\>"
-syn match   coqKwd             contained "|\|/\\\|\\/\|<->\|\~\|->\|=>\|{\|}\|&\|+\|-\|*\|=\|>\|<\|<="
+syn match   coqKwd             contained "\<exists!\?\>" conceal cchar=∃
+syn match   coqKwd             contained "|\|<->\|->\|=>\|{\|}\|&\|+\|-\|*\|=\|>\|<\|<="
 syn match coqTermPunctuation   contained ":=\|:>\|:\|;\|,\|||\|\[\|\]\|@\|?\|\<_\>\|<+"
+
+highlight clear Conceal
+highlight link Conceal coqKwd
 
 " Various
 syn region coqRequire contains=coqString matchgroup=coqVernacCmd start="\<Require\>\%(\_s\+\%(Export\|Import\)\>\)\?" matchgroup=coqVernacPunctuation end="\.\_s"


### PR DESCRIPTION
I hard-coded symbols I like to have concealed. As such, this PR should not be merged, but if someone feels like they'd benefit from having those symbols, just use this fork. Rated issue: #370 

Note: in order for it to work, `:set conceallevel=2` or `lua vim.o.conceallevel = 2`.

