### PR TITLE
Fix RocqToggleDebug regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased ([main])
 
+### Fixed
+- Allow calling `:RocqToggleDebug` before `:RocqStart` and store the path to the
+  log file in `b:coqtail_log_name`.
+  (PR #388)
+
 ## [1.8.0]
 
 ### Added

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -347,7 +347,16 @@ endfunction
 function! coqtail#start(after_start_func, coq_args) abort
   if s:running()
     call coqtail#util#warn('Rocq is already running.')
-  elseif s:initted()
+  elseif s:initted() && b:coqtail_log_name ==# ''
+    " Hack: The left side of this condition is here to ensure that no commands
+    " can run before `RocqStart` has completed, which avoids possible race
+    " conditions. See https://github.com/whonore/Coqtail/issues/364 and
+    " https://github.com/whonore/Coqtail/pull/366 for details. The right side
+    " is a hack to make an exception for `RocqToggleDebug`, which we do want to
+    " allow before `RocqStart` in order to log errors during startup. This
+    " means you can trigger the race condition with something like
+    " `RocqToggleDebug | RocqStop` followed by `RocqToLine | RocqToLine`, but
+    " maybe just don't and everything should be fine.
     call coqtail#util#warn('Rocq is still starting.')
   else
     " See comment in coqtail#init() about buffer-local variables

--- a/python/coqtail.py
+++ b/python/coqtail.py
@@ -827,8 +827,10 @@ class Coqtail:
         log = self.coqtop.toggle_debug()
         if log is None:
             msg = "Debugging disabled."
+            self.log = ""
         else:
             msg = f"Debugging enabled. Log: {log}."
+            self.log = log
 
         self.set_info(msg, reset=True)
         self.refresh(goals=False, opts=opts)


### PR DESCRIPTION
Fixes #387 

- Re-enable calling RocqToggleDebug before RocqStart
- Store the log path in b:coqtail_log_name