### PR TITLE
support _RocqProject

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,13 +174,13 @@ the current file on `:RocqStart` by setting `g:coqtail_dune_compile_deps = 1`.
 #### _CoqProject Settings
 
 By default, Coqtail searches the current and parent directories for a
-`_CoqProject` file, but additional or different project files can be specified
-with `g:coqtail_project_files`.
+`_CoqProject` or `_RocqProject` file, but additional or different project files can be specified
+with `g:coqtail_project_names`.
 If multiple files are found, their argument lists will be concatenated.
 For example, to include arguments from both `_CoqProject` and `_CoqProject.local`:
 
 ```vim
-let g:coqtail_project_files = ['_CoqProject', '_CoqProject.local']
+let g:coqtail_project_names = ['_CoqProject', '_CoqProject.local']
 ```
 
 ### Syntax Highlighting and Indentation

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -31,7 +31,7 @@ let s:port = -1
 
 " Default CoqProject file name.
 if !exists('g:coqtail_project_names')
-  let g:coqtail_project_names = ['_CoqProject']
+  let g:coqtail_project_names = ['_CoqProject', '_RocqProject']
 endif
 
 " Default to updating the tagstack on coqtail#gotodef.

--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -284,7 +284,7 @@ g:coqtail_project_names	The names of Rocq project files to search for in Rocq
 			files are parsed and passed as arguments to Rocq
 			by `:RocqStart`.
 
-			Default: ['_CoqProject']
+			Default: ['_CoqProject', '_RocqProject']
 
 						       *b:coqtail_project_files*
 b:coqtail_project_files	Paths to the Rocq project files found during `:RocqStart`.


### PR DESCRIPTION
Rocq 9.0 defaults to using `_RocqProject` files.
This change supports both those and the old `_CoqProject` files.
