### PR TITLE
Fix exit behavior (#395)

### DIFF
--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -517,11 +517,6 @@ function! coqtail#stop() abort
   silent! autocmd! coqtail#Sync * <buffer>
 
   call s:call('stop', 'coqtail#cleanupCB', 1, {})
-endfunction
-
-" Clean up commands, panels, and autocommands.
-function! coqtail#cleanupCB(chan, msg) abort
-  call s:unlock_buffer(a:msg.buf)
 
   " Close the channel
   silent! call b:coqtail_chan.close()
@@ -531,6 +526,11 @@ function! coqtail#cleanupCB(chan, msg) abort
 
   " Clean up auxiliary panels
   call coqtail#panels#cleanup()
+endfunction
+
+" Clean up commands, panels, and autocommands.
+function! coqtail#cleanupCB(chan, msg) abort
+  call s:unlock_buffer(a:msg.buf)
 endfunction
 
 " Advance/rewind Rocq to the specified position.

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -528,7 +528,6 @@ function! coqtail#stop() abort
   call coqtail#panels#cleanup()
 endfunction
 
-" Clean up commands, panels, and autocommands.
 function! coqtail#cleanupCB(chan, msg) abort
   call s:unlock_buffer(a:msg.buf)
 endfunction


### PR DESCRIPTION
This fixes the weird behavior of `:q` that Coqtail had from version 8aadf87458b4b173107e604d98db5f7dd9c8f593 on. A first call closed all auxiliary Coqtail panels only. A second one was required for taking care of the main buffer.