### PR TITLE
Fix RocqStop failing the second time, fix enable proof diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
   (PR #407)
 
 ### Fixed
+- After starting, stopping, and restarting Rocq, `:RocqStop` still works.
+  (PR #409)
+- Proof diffs are once again enabled at `:RocqStart` if
+  `g/b:coqtail_auto_set_proof_diffs` is set to `on`.
+  (PR #409)
+
+### Fixed
 - Print an error message on `:RocqStart` if `coqidetop` (or
   `b:coqtail_coq_prog`) cannot be found.
   (PR #401)

--- a/autoload/coqtail/panels.vim
+++ b/autoload/coqtail/panels.vim
@@ -390,12 +390,23 @@ function! coqtail#panels#cleanup() abort
   endtry
 endfunction
 
+" Get the main panel's buffer number.
+function! coqtail#panels#getmain() abort
+  if exists('b:coqtail_panel_bufs')
+    return b:coqtail_panel_bufs.main
+  else
+    " If b:coqtail_panel_bufs doesn't exist, then the other panels aren't
+    " initialized and this must be the main buffer.
+    return bufnr('%')
+  endif
+endfunction
+
 " Getter for variables local to the main buffer
 function! coqtail#panels#getvar(var) abort
-  return getbufvar(b:coqtail_panel_bufs.main, a:var)
+  return getbufvar(coqtail#panels#getmain(), a:var)
 endfunction
 
 " Setter for variables local to the main buffer
 function! coqtail#panels#setvar(var, val) abort
-  return setbufvar(b:coqtail_panel_bufs.main, a:var, a:val)
+  return setbufvar(coqtail#panels#getmain(), a:var, a:val)
 endfunction


### PR DESCRIPTION
After starting, stopping, and restarting Rocq, `RocqStop` did nothing. This was because `coqtail#stop` called `coqtail#panels#cleanup` before `s:call('stop')`. `s:call` checks `s:initted`, which uses `coqtail#panels#getvar` to look up `coqtail_chan` in the main panel's buffer. The problem was `coqtail#panels#cleanup` `unlet`s `b:coqtail_panel_bufs`, so `coqtail_panels#getvar` failed.

The solution is to use `coqtail#panels#getmain` instead, which gracefully handles the situation where `b:coqtail_panel_bufs` does not exist.

`s:init_proof_diffs` was also silently failing since it was called before `b:coqtail_started` was set.

Fixes #406