### PR TITLE
Fix colors for terminal with light background

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,22 +201,22 @@ By default these are defined as:
 if &t_Co > 16
   if &background ==# 'dark'
     hi def CoqtailChecked ctermbg=17 guibg=#113311
-    hi def CoqtailSent ctermbg=60 guibg=#007630
+    hi def CoqtailSent    ctermbg=60 guibg=#007630
   else
     hi def CoqtailChecked ctermbg=157 guibg=LightGreen
-    hi def CoqtailSent ctermbg=40 guibg=LimeGreen
+    hi def CoqtailSent    ctermbg=40  guibg=LimeGreen
   endif
 else
   hi def CoqtailChecked ctermbg=4 guibg=LightGreen
-  hi def CoqtailSent ctermbg=7 guibg=LimeGreen
+  hi def CoqtailSent    ctermbg=7 guibg=LimeGreen
 endif
-hi def link CoqtailError Error
-hi def link CoqtailOmitted coqProofAdmit
+hi def link CoqtailError         Error
+hi def link CoqtailOmitted       coqProofAdmit
 ```
 
 To override these defaults simply set your own highlighting (`:help :hi`) before
 `syntax/coq.vim` is sourced (e.g., in your `.vimrc`).
-Note, however, that many colorschemes call `syntax clear`, which clears
+Note, however, that many colorschemes call `hi clear`, which clears
 user-defined highlighting, so it is recommended to place your settings in a
 `ColorScheme` autocommand.
 For example:

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -37,21 +37,21 @@ if !exists('b:coqtail_did_highlight') || !b:coqtail_did_highlight
     elseif &t_Co > 16
       if &background ==# 'dark'
         hi def CoqtailChecked ctermbg=17 guibg=#113311
-        hi def CoqtailSent ctermbg=60 guibg=#007630
+        hi def CoqtailSent    ctermbg=60 guibg=#007630
       else
         hi def CoqtailChecked ctermbg=157 guibg=LightGreen
-        hi def CoqtailSent ctermbg=40 guibg=LimeGreen
+        hi def CoqtailSent    ctermbg=40  guibg=LimeGreen
       endif
     else
       hi def CoqtailChecked ctermbg=4 guibg=LightGreen
-      hi def CoqtailSent ctermbg=7 guibg=LimeGreen
+      hi def CoqtailSent    ctermbg=7 guibg=LimeGreen
     endif
-    hi def link CoqtailDiffAdded DiffText
-    hi def link CoqtailDiffAddedBg DiffChange
-    hi def link CoqtailDiffRemoved DiffDelete
+    hi def link CoqtailDiffAdded     DiffText
+    hi def link CoqtailDiffAddedBg   DiffChange
+    hi def link CoqtailDiffRemoved   DiffDelete
     hi def link CoqtailDiffRemovedBg DiffDelete
-    hi def link CoqtailError Error
-    hi def link CoqtailOmitted coqProofAdmit
+    hi def link CoqtailError         Error
+    hi def link CoqtailOmitted       coqProofAdmit
   endfunction
 
   call s:CoqtailHighlight()
@@ -68,7 +68,8 @@ if !exists('b:coqtail_did_highlight') || !b:coqtail_did_highlight
       autocmd TermResponseAll *
             \ if expand("<amatch>") ==# 'background'
             \ |   hi clear CoqtailChecked
-            \ |   hi clear CoqtailSent | call s:CoqtailHighlight()
+            \ |   hi clear CoqtailSent
+            \ |   call s:CoqtailHighlight()
             \ | endif
     endif
 


### PR DESCRIPTION
When `termguicolors` is disabled a dark blue background is used for light colorschemes and it makes the checked code unreadable.