### PR TITLE
Fix incorrect filetype detection for other languages

### DIFF
--- a/ftdetect/coq.vim
+++ b/ftdetect/coq.vim
@@ -1,7 +1,6 @@
-" Default to coq when editing a file that doesn't exists
-au BufNewFile *.v set filetype=coq
-
-" Rely on filetype detection for existing files except in old verions of Vim
-if !has('patch-9.0.1478')
-  au BufRead *.v set filetype=coq
-endif
+" Use built-in filetype detection unless Vim doesn't support it or we are
+" editing an empty file
+au BufRead,BufNewFile *.v
+      \ if !has('patch-9.0.1478') || (line('$') == 1 && getline(1) =~ '^\s*$')
+      \ |   set filetype=coq
+      \ | endif


### PR DESCRIPTION
The .v extension is used by Coq, Verilog and V. After patch 9.0.1478 Vim is able to distinguish them based on their contents but Coqtail was forcing the coq filetype for all of them. This PR fixes that.