### PR TITLE
Set wildignore; Move global variables to plugin/

### DIFF
--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -1,12 +1,6 @@
 " Author: Wolf Honore
 " Coqtail Python interface and window management.
 
-" Only source once.
-if exists('g:loaded_coqtail')
-  finish
-endif
-let g:loaded_coqtail = 1
-
 let s:python_dir = expand('<sfile>:p:h:h') . '/python'
 let g:coqtail#supported = coqtail#compat#init(s:python_dir)
 if !g:coqtail#supported
@@ -28,31 +22,6 @@ let s:unsupported_msg =
   \ 'Continuing with the interface for the latest supported version (%s).'
 " Server port.
 let s:port = -1
-
-" Default CoqProject file name.
-if !exists('g:coqtail_project_names')
-  let g:coqtail_project_names = ['_CoqProject', '_RocqProject']
-endif
-
-" Default to updating the tagstack on coqtail#gotodef.
-if !exists('g:coqtail_update_tagstack')
-  let g:coqtail_update_tagstack = 1
-endif
-
-" Default to not treating all stderr messages as warnings.
-if !exists('g:coqtail_treat_stderr_as_warning')
-  let g:coqtail_treat_stderr_as_warning = 0
-endif
-
-" Default to preferring dune if in a dune project.
-if !exists('g:coqtail_build_system')
-  let g:coqtail_build_system = 'prefer-dune'
-endif
-
-" Default to not compiling deps
-if !exists('g:coqtail_dune_compile_deps')
-  let g:coqtail_dune_compile_deps = 0
-endif
 
 " Find the path corresponding to 'lib'. Used by includeexpr.
 function! coqtail#findlib(lib) abort

--- a/plugin/coqtail.vim
+++ b/plugin/coqtail.vim
@@ -1,0 +1,34 @@
+" Only source once.
+if exists('g:loaded_coqtail')
+  finish
+endif
+let g:loaded_coqtail = 1
+
+" Initialize global variables.
+" Default CoqProject file name.
+if !exists('g:coqtail_project_names')
+  let g:coqtail_project_names = ['_CoqProject', '_RocqProject']
+endif
+
+" Default to updating the tagstack on coqtail#gotodef.
+if !exists('g:coqtail_update_tagstack')
+  let g:coqtail_update_tagstack = 1
+endif
+
+" Default to not treating all stderr messages as warnings.
+if !exists('g:coqtail_treat_stderr_as_warning')
+  let g:coqtail_treat_stderr_as_warning = 0
+endif
+
+" Default to preferring dune if in a dune project.
+if !exists('g:coqtail_build_system')
+  let g:coqtail_build_system = 'prefer-dune'
+endif
+
+" Default to not compiling deps
+if !exists('g:coqtail_dune_compile_deps')
+  let g:coqtail_dune_compile_deps = 0
+endif
+
+" Use 'set' because wildignore is a global option
+set wildignore+=*.vo,*.vo[ks],*.glob


### PR DESCRIPTION
The best place to set `wildignore` is inside the `plugin/` directory since it is always sourced by `vim`. This way one can start `vim` without arguments and still not see ignored files when doing `:e`, for example (this wouldn't be case if it was set in `ftplugin/coq.vim`).

I also noticed that global variables are declared inside `autoload/` instead of  `plugin/` but they are still defined (by accident) because `ftplugin/coq.vim` calls an autoloaded function and therefore `autoload/coqtail.vim` is sourced.
If you remove `ftplugin/coq.vim` you can see with `:scriptnames` that no file inside `autoload/` is sourced and the global variables are not defined.