### PR TITLE
Add local version of 'joinspaces' for Rocq buffers

### DIFF
--- a/doc/coqtail.txt
+++ b/doc/coqtail.txt
@@ -465,6 +465,12 @@ g:coqtail_treat_stderr_as_warning
 
 			Default: 0
 
+                                                         *g:coqtail_joinspaces*
+g:coqtail_joinspaces
+			A local version of 'joinspaces' for Rocq buffers.
+
+			Default: 0
+
 =======================
 Backwards Compatibility			       *coqtail-backwards-compatibility*
 

--- a/ftplugin/coq.vim
+++ b/ftplugin/coq.vim
@@ -10,6 +10,14 @@ if g:coqtail#supported
   call coqtail#register()
 endif
 
+if !get(g:, 'coqtail_joinspaces', 0)
+  augroup coqtail_joinspaces
+    autocmd!
+    autocmd BufEnter <buffer> let b:coqtail_save_js = &joinspaces | set nojoinspaces
+    autocmd BufLeave <buffer> let &joinspaces = get(b:, 'coqtail_save_js', 1)
+  augroup END
+endif
+
 " Comments
 if has('comments')
   setlocal commentstring=(*%s*)


### PR DESCRIPTION
The option `joinspaces` is set to 1 by default and it's very annoying when two spaces are added after joining tactics.