### PR TITLE
Clean up Vim code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,30 @@ git clone https://github.com/whonore/Coqtail.git ~/.vim/pack/coq/start/Coqtail
 vim +helptags\ ~/.vim/pack/coq/start/Coqtail/doc +q
 ```
 
-Using [pathogen]:
+Using [vim-plug]:
+```vim
+" Add this line in your .vimrc
+Plug 'whonore/Coqtail'
+```
+and in the command line run
+```sh
+vim +PlugInstall +qa
+```
+
+Using [vim-pathogen]:
 ```sh
 git clone https://github.com/whonore/Coqtail.git ~/.vim/bundle/Coqtail
 vim +Helptags +q
 ```
 
 Using [Vundle]:
-```sh
-Plugin 'whonore/Coqtail' (add this line in .vimrc)
-vim +PluginInstall +qa
+```vim
+" Add this line in your .vimrc
+Plugin 'whonore/Coqtail'
 ```
-
-Using [VimPlug]:
+and in the command line run
 ```sh
-Plug 'whonore/Coqtail' (add this line in .vimrc)
-vim +PlugInstall +qa
+vim +PluginInstall +qa
 ```
 
 ### Requirements
@@ -145,17 +153,17 @@ are included, which you can use to create new ones.
 
 | Mapping | Description |
 |---|---|
-| `<Plug>(proof-text-object-inner)` | Operator pending and visual modes, mapped to iP by default. |
-| `<Plug>(proof-text-object-outer)` | Operator pending and visual modes, mapped to aP by default. |
+| `<Plug>(proof-text-object-inner)` | Operator pending and visual modes |
+| `<Plug>(proof-text-object-outer)` | Operator pending and visual modes |
 
 The default mappings are shown below, you can copy these if you wish
 to customise them in your `.vimrc`:
 
 ```vim
-	omap iP <Plug>(proof-text-object-inner)
-	xmap iP <Plug>(proof-text-object-inner)
-	omap aP <Plug>(proof-text-object-outer)
-	xmap aP <Plug>(proof-text-object-outer)
+omap iP <Plug>(proof-text-object-inner)
+xmap iP <Plug>(proof-text-object-inner)
+omap aP <Plug>(proof-text-object-outer)
+xmap aP <Plug>(proof-text-object-outer)
 ```
 
 ### Rocq Executable
@@ -280,18 +288,27 @@ override these defaults.
 
 See `:help coqtail-configuration` for a description of all the configuration options.
 
-## Vim Plugin Interoperability
+## Supported Plugins
 
-### Jumping between matches
+### matchit / vim-matchup
 
 Coqtail defines `b:match_words` patterns to support jumping between matched text
-with `%` using the [matchup] or [matchit] plugins.
+with `%` using the [vim-matchup] or [matchit] plugins.
 
-### Automatically closing blocks
+> [!TIP]
+> The matchit plugin is already shipped with your Vim installation, to use it add this line to your .vimrc:
+> ```vim
+> packadd! matchit
+> ```
+> See `:h matchit` for more.
+
+### vim-endwise
 
 Coqtail defines patterns to enable automatic insertion of the appropriate `End`
 command for code blocks such as `Section`s, `Module`s, and `match` expressions
-with [endwise].
+with [vim-endwise].
+
+## Editor Improvements
 
 ### Tags
 
@@ -302,17 +319,17 @@ where the term is defined has already been evaluated by Rocq.
 An alternative is to disable Coqtail's default `tagfunc` (`let g:coqtail_tagfunc
 = 0`) and instead use [universal-ctags] in conjunction with [coq.ctags], to
 statically generate a `tags` file.
-This works especially well with something like the [gutentags] plugin to
+This works especially well with something like the [vim-gutentags] plugin to
 automatically keep the `tags` file in sync with the Rocq source.
 
-### Latex/Unicode input
+### Unicode input
 
 Coqtail and Rocq can handle non-ASCII characters in identifiers, notations,
 etc., but Coqtail does not provide a method for inputting these characters itself.
 Instead one can use one of the native Vim options (e.g.,
 [`i_CTRL-K`](https://vimhelp.org/insert.txt.html#i_CTRL-K) or
 [`i_CTRL-V_digit`](https://vimhelp.org/insert.txt.html#i_CTRL-V_digit)) or a
-plugin like [latex-unicoder] or [unicode.vim].
+plugin like [latex-unicoder.vim] or [unicode.vim].
 
 ## Thanks
 
@@ -323,11 +340,12 @@ License, Copyright (c) 2013, Thomas Refis).
 
 #### Python 2 Support
 
-Python 2 and 3.5 have reached their [end-of-life](https://pythonclock.org/) so
-Coqtail no longer supports them in order to simplify the code and take advantage
-of newer features.
-See [YouCompleteMe] for help building Vim with Python 3 support.
-If you cannot upgrade Vim, the [python2] branch still supports older Pythons.
+> [!WARNING]
+> Python 2 and 3.5 have reached their [end-of-life](https://pythonclock.org/) so
+> Coqtail no longer supports them in order to simplify the code and take advantage
+> of newer features.
+> See [YouCompleteMe] for help building Vim with Python 3 support.
+> If you cannot upgrade Vim, the [python2] branch still supports older Pythons.
 
 [python2]: https://github.com/whonore/Coqtail/tree/python2
 [Rocq 8.4 - 9.2]: https://rocq-prover.org/install
@@ -335,19 +353,19 @@ If you cannot upgrade Vim, the [python2] branch still supports older Pythons.
 [ProofGeneral]: https://proofgeneral.github.io/
 [XML protocol]: https://github.com/coq/coq/blob/master/dev/doc/xml-protocol.md
 [vim package]: https://vimhelp.org/repeat.txt.html#packages
-[pathogen]: https://github.com/tpope/vim-pathogen
+[vim-pathogen]: https://github.com/tpope/vim-pathogen
 [Vundle]: https://github.com/VundleVim/Vundle.vim
-[VimPlug]: https://github.com/junegunn/vim-plug
+[vim-plug]: https://github.com/junegunn/vim-plug
 [syntax]: http://www.vim.org/scripts/script.php?script_id=2063
 [indent]: http://www.vim.org/scripts/script.php?script_id=2079
-[matchup]: https://github.com/andymass/vim-matchup
-[matchit]: http://ftp.vim.org/pub/vim/runtime/macros/matchit.txt
-[endwise]: https://github.com/tpope/vim-endwise
+[vim-matchup]: https://github.com/andymass/vim-matchup
+[matchit]: https://vimhelp.org/matchit.txt.html
+[vim-endwise]: https://github.com/tpope/vim-endwise
 [proof diffs]: https://rocq-prover.org/doc/master/refman/proofs/writing-proofs/proof-mode.html#coq:opt.Diffs
 [Coquille]: https://github.com/the-lambda-church/coquille
 [YouCompleteMe]: https://github.com/ycm-core/YouCompleteMe/wiki/Building-Vim-from-source
 [universal-ctags]: https://github.com/universal-ctags/ctags
 [coq.ctags]: https://github.com/tomtomjhj/coq.ctags
-[gutentags]: https://github.com/ludovicchabant/vim-gutentags
-[latex-unicoder]: https://github.com/joom/latex-unicoder.vim
+[vim-gutentags]: https://github.com/ludovicchabant/vim-gutentags
+[latex-unicoder.vim]: https://github.com/joom/latex-unicoder.vim
 [unicode.vim]: https://github.com/chrisbra/unicode.vim

--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -1,25 +1,14 @@
 " Author: Wolf Honore
 " Coqtail Python interface and window management.
 
-let s:python_dir = expand('<sfile>:p:h:h') . '/python'
-let g:coqtail#supported = coqtail#compat#init(s:python_dir)
-if !g:coqtail#supported
-  call coqtail#util#warn(
-    \ "Coqtail requires Python 3.6 or later.\n" .
-    \ 'See https://github.com/whonore/Coqtail/blob/main/README.md#python-2-support.'
-  \)
-  finish
-endif
-
-py3 from coqtail import CoqtailServer
-
-" Initialize global variables.
 " Default number of lines of a goal to show.
 let s:goal_lines = 5
+
 " Warning/error messages.
 let s:unsupported_msg =
   \ "Coqtail does not officially support your version of Rocq (%s).\n" .
   \ 'Continuing with the interface for the latest supported version (%s).'
+
 " Server port.
 let s:port = -1
 

--- a/ftplugin/coq.vim
+++ b/ftplugin/coq.vim
@@ -4,18 +4,19 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = []
-
-if g:coqtail#supported
+if g:coqtail_supported
   call coqtail#register()
 endif
 
-if !get(g:, 'coqtail_joinspaces', 0)
-  augroup coqtail_joinspaces
-    autocmd!
-    autocmd BufEnter <buffer> let b:coqtail_save_js = &joinspaces | set nojoinspaces
-    autocmd BufLeave <buffer> let &joinspaces = get(b:, 'coqtail_save_js', 1)
-  augroup END
+let b:undo_ftplugin = 'setl sua< inc<'
+
+setlocal suffixesadd=.v
+setlocal include=\\<Require\\>\\(\\_s*\\(Import\\\|Export\\)\\>\\)\\?
+
+" Follow imports
+if g:coqtail_supported
+  setlocal includeexpr=coqtail#findlib(v:fname)
+  let b:undo_ftplugin .= ' | setl inex<'
 endif
 
 " Comments
@@ -25,21 +26,13 @@ if has('comments')
   " NOTE: The 'r' and 'o' flags mistake the '*' bullet as a middle comment and
   " will automatically add an extra one after <Enter>, 'o' or 'O'.
   setlocal formatoptions-=t formatoptions-=r formatoptions-=o formatoptions+=cql
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'setl cms< com< fo<')
-endif
-
-" Follow imports
-if g:coqtail#supported
-  setlocal includeexpr=coqtail#findlib(v:fname)
-  setlocal suffixesadd=.v
-  setlocal include=\\<Require\\>\\(\\_s*\\(Import\\\|Export\\)\\>\\)\\?
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'setl inex< sua< inc<')
+  let b:undo_ftplugin .= ' | setl cms< com< fo<'
 endif
 
 " Tags
-if exists('+tagfunc') && g:coqtail#supported && get(g:, 'coqtail_tagfunc', 1)
+if exists('+tagfunc') && g:coqtail_supported && get(g:, 'coqtail_tagfunc', 1)
   setlocal tagfunc=coqtail#gettags
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'setl tfu<')
+  let b:undo_ftplugin .= ' | setl tfu<'
 endif
 
 " Maps
@@ -57,14 +50,14 @@ if !get(g:, 'coqtail_nomap', 0)
   nnoremap <buffer> <silent> ][ :<C-u>call coqtail#search#proof('W', v:count1, 0)<CR>
   xnoremap <buffer> <silent> ][ :<C-u>call coqtail#search#proof('W', v:count1, 1)<CR>
 
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! nunmap <buffer> [[')
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! xunmap <buffer> [[')
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! nunmap <buffer> ]]')
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! xunmap <buffer> ]]')
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! nunmap <buffer> []')
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! xunmap <buffer> []')
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! nunmap <buffer> ][')
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! xunmap <buffer> ][')
+  let b:undo_ftplugin .= ' | silent! nunmap <buffer> [['
+  let b:undo_ftplugin .= ' | silent! xunmap <buffer> [['
+  let b:undo_ftplugin .= ' | silent! nunmap <buffer> ]]'
+  let b:undo_ftplugin .= ' | silent! xunmap <buffer> ]]'
+  let b:undo_ftplugin .= ' | silent! nunmap <buffer> []'
+  let b:undo_ftplugin .= ' | silent! xunmap <buffer> []'
+  let b:undo_ftplugin .= ' | silent! nunmap <buffer> ]['
+  let b:undo_ftplugin .= ' | silent! xunmap <buffer> ]['
 endif
 
 " Proof text object
@@ -79,10 +72,10 @@ if !get(g:, 'coqtail_nomap', 0)
   omap <buffer> aP <Plug>(proof-text-object-outer)
   xmap <buffer> aP <Plug>(proof-text-object-outer)
 
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! ounmap <buffer> iP')
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! xunmap <buffer> iP')
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! ounmap <buffer> aP')
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'silent! xunmap <buffer> aP')
+  let b:undo_ftplugin .= ' | silent! ounmap <buffer> iP'
+  let b:undo_ftplugin .= ' | silent! xunmap <buffer> iP'
+  let b:undo_ftplugin .= ' | silent! ounmap <buffer> aP'
+  let b:undo_ftplugin .= ' | silent! xunmap <buffer> aP'
 endif
 
 " matchit/matchup patterns
@@ -93,13 +86,13 @@ if (exists('g:loaded_matchit') || exists('g:loaded_matchup')) && !exists('b:matc
   let s:proof_start = '\%(' . join(map(s:proof_starts, '"\\<" . v:val . "\\>"'), '\|') . '\)'
   let s:proof_end = '\%(' . join(map(s:proof_ends, '"\\<" . v:val . "\\>"'), '\|') . '\)'
   let b:match_words = join([
-    \ '\<if\>:\<then\>:\<else\>',
-    \ '\<let\>:\<in\>',
-    \ '\<\%(lazy\|multi\)\?match\>:\<with\>:\<end\>',
-    \ '\%(\<Section\>\|\<Module\>\):\<End\>',
-    \ s:proof_start . ':' . s:proof_end
-  \], ',')
-  let b:undo_ftplugin = add(b:undo_ftplugin, 'unlet! b:match_ignorecase b:match_words')
+        \ '\<if\>:\<then\>:\<else\>',
+        \ '\<let\>:\<in\>',
+        \ '\<\%(lazy\|multi\)\?match\>:\<with\>:\<end\>',
+        \ '\%(\<Section\>\|\<Module\>\):\<End\>',
+        \ s:proof_start . ':' . s:proof_end
+        \], ',')
+  let b:undo_ftplugin .= ' | unlet! b:match_ignorecase b:match_words'
 endif
 
 " endwise
@@ -111,9 +104,19 @@ if exists('g:loaded_endwise')
   let b:endwise_pattern = '\%(' . s:section_pat . '\|' . s:match_pat . '\)'
   let b:endwise_syngroups = 'coqVernacCmd,coqKwd,coqLtac'
   unlet! b:endwise_end_pattern
-  let b:undo_ftplugin = add(
-    \ b:undo_ftplugin,
-    \ 'unlet! b:endwise_addition b:endwise_words b:endwise_pattern b:endwise_syngroups')
+  let b:undo_ftplugin .= ' | unlet! b:endwise_addition b:endwise_words b:endwise_pattern b:endwise_syngroups'
 endif
 
-let b:undo_ftplugin = join(b:undo_ftplugin, ' | ')
+" Use g:coqtail_joinspaces as the local version of 'joinspaces'
+augroup CoqtailJoinspaces
+  autocmd!
+  autocmd BufEnter <buffer>
+        \ if !exists('b:_coqtail_save_js')
+        \ |   let b:_coqtail_save_js = &js
+        \ | endif
+        \ | let &joinspaces = get(g:, 'coqtail_joinspaces', 0)
+
+  autocmd BufLeave <buffer>
+        \ let &joinspaces = get(b:, '_coqtail_save_js', 1)
+        \ | unlet b:_coqtail_save_js
+augroup END

--- a/plugin/coqtail.vim
+++ b/plugin/coqtail.vim
@@ -4,6 +4,19 @@ if exists('g:loaded_coqtail')
 endif
 let g:loaded_coqtail = 1
 
+let s:python_dir = expand('<sfile>:p:h:h') . '/python'
+let g:coqtail_supported = coqtail#compat#init(s:python_dir)
+
+if !g:coqtail_supported
+  call coqtail#util#warn(
+        \ "Coqtail requires Python 3.6 or later.\n" .
+        \ 'See https://github.com/whonore/Coqtail/blob/main/README.md#python-2-support.'
+        \)
+  finish
+endif
+
+py3 from coqtail import CoqtailServer
+
 " Initialize global variables.
 " Default CoqProject file name.
 if !exists('g:coqtail_project_names')

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -57,7 +57,7 @@ if !exists('b:coqtail_did_highlight') || !b:coqtail_did_highlight
   call s:CoqtailHighlight()
   " NOTE: Setting a colorscheme usually calls 'hi clear' so have to set
   " Coqtail highlighting colors again
-  augroup coqtail_highlight
+  augroup CoqtailHighlight
     autocmd!
     autocmd ColorScheme * call s:CoqtailHighlight()
 


### PR DESCRIPTION
I fixed `g:coqtail_joinspaces`  because it didn't actually restore the previous value of `joinspaces` when leaving the buffer and did some minor changes to clean up the Vim code and the README.