### PR TITLE
Speed up initialization and refactor Vim code

### DIFF
--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -246,6 +246,7 @@ endfunction
 " Initialize Python interface.
 function! coqtail#init() abort
   if s:port == -1
+    py3 from coqtail import CoqtailServer
     let s:port = py3eval(printf(
       \ 'CoqtailServer.start_server(bool(%d))',
       \ !g:coqtail#compat#has_channel))

--- a/ftplugin/coq.vim
+++ b/ftplugin/coq.vim
@@ -3,15 +3,22 @@ if exists('b:did_ftplugin')
   finish
 endif
 let b:did_ftplugin = 1
+let b:undo_ftplugin = 'setl sua< inc<'
+
+if !g:coqtail_supported
+  call coqtail#util#warn(
+        \ "Coqtail requires Python 3.6 or later.\n" .
+        \ 'See https://github.com/whonore/Coqtail/blob/main/README.md#python-2-support.'
+        \)
+  finish
+endif
+
+setlocal suffixesadd=.v
+setlocal include=\\<Require\\>\\(\\_s*\\(Import\\\|Export\\)\\>\\)\\?
 
 if g:coqtail_supported
   call coqtail#register()
 endif
-
-let b:undo_ftplugin = 'setl sua< inc<'
-
-setlocal suffixesadd=.v
-setlocal include=\\<Require\\>\\(\\_s*\\(Import\\\|Export\\)\\>\\)\\?
 
 " Follow imports
 if g:coqtail_supported

--- a/ftplugin/coq.vim
+++ b/ftplugin/coq.vim
@@ -3,18 +3,17 @@ if exists('b:did_ftplugin')
   finish
 endif
 let b:did_ftplugin = 1
-let b:undo_ftplugin = 'setl sua< inc<'
 
 if !g:coqtail_supported
   call coqtail#util#warn(
         \ "Coqtail requires Python 3.6 or later.\n" .
         \ 'See https://github.com/whonore/Coqtail/blob/main/README.md#python-2-support.'
         \)
-  finish
 endif
 
 setlocal suffixesadd=.v
 setlocal include=\\<Require\\>\\(\\_s*\\(Import\\\|Export\\)\\>\\)\\?
+let b:undo_ftplugin = 'setl sua< inc<'
 
 if g:coqtail_supported
   call coqtail#register()

--- a/indent/coq.vim
+++ b/indent/coq.vim
@@ -45,6 +45,14 @@ let s:rewrite = '\<Rewrite\_s\+Rule\>'
 let s:vbar_cmd = '\%(' . s:inductive . '\|' . s:rewrite . '\)'
 let s:lineend = '\s*$'
 
+" Get effective value of 'shiftwidth'
+function! s:shiftwidth() abort
+  if has('patch-7.3.694')
+    return shiftwidth()
+  else
+    return &sw ? &sw : &ts
+endfunction
+
 " Match syntax groups.
 function! s:matchsyn(line, col, syns) abort
   return printf(
@@ -244,7 +252,7 @@ function! s:GetCoqIndent() abort
   " current line begins with '|':
   if l:currentline =~# '^\s*|[|}]\@!'
     let l:match = s:indent_of_previous_pair(s:match, '', '\<end\>', 1, ['string', 'comment'])
-    let l:off = get(g:, 'coqtail_inductive_shift', 1) * &sw
+    let l:off = get(g:, 'coqtail_inductive_shift', 1) * s:shiftwidth()
     return l:match != -1 ? l:match : s:indent_of_previous('^\s*' . s:vbar_cmd) + l:off
   endif
 
@@ -264,7 +272,7 @@ function! s:GetCoqIndent() abort
 
   " start of proof
   if l:previousline =~# s:proofstart . s:lineend
-    return l:ind + &sw
+    return l:ind + s:shiftwidth()
   endif
 
   " bullet on current line
@@ -293,7 +301,7 @@ function! s:GetCoqIndent() abort
   if l:previousline =~# '^\s*\%(Section\|Module\)\>'
     " don't indent if Section/Module is empty or is defined on one line
     if l:currentline !~# '^\s*End\>' && l:previousline !~# ':=.*\.\s*$' && l:previousline !~# '\<End\>'
-      return l:ind + &sw
+      return l:ind + s:shiftwidth()
     endif
     " fall through
   endif
@@ -310,17 +318,17 @@ function! s:GetCoqIndent() abort
 
   " previous line has the form '|...'
   if l:previousline =~# '[{|]\@1<!|\%([^|}]\%(\.\|\<end\>\)\@!\)*$'
-    return l:ind + get(g:, 'coqtail_match_shift', 2) * &sw
+    return l:ind + get(g:, 'coqtail_match_shift', 2) * s:shiftwidth()
   endif
 
   " previous line has '{|' or '{' with no matching '|}' or '}'
   if l:previousline =~# '{|\?[^}]*\s*$'
-    return l:ind + &sw
+    return l:ind + s:shiftwidth()
   endif
 
   " unterminated vernacular sentences
   if l:previousline =~# s:vernac . '.*[^.[:space:]]\s*$' && l:previousline !~# '^\s*$'
-    return l:ind + &sw
+    return l:ind + s:shiftwidth()
   endif
 
   " back to normal indent after lines ending with '.'
@@ -334,12 +342,12 @@ function! s:GetCoqIndent() abort
 
   " previous line ends with 'with'
   if l:previousline =~# '\<with\s*$'
-    return l:ind + &sw
+    return l:ind + s:shiftwidth()
   endif
 
   " unterminated 'let ... in'
   if l:previousline =~# '\<let\>\%(.\%(\<in\>\)\@!\)*$'
-    return l:ind + &sw
+    return l:ind + s:shiftwidth()
   endif
 
   " else

--- a/plugin/coqtail.vim
+++ b/plugin/coqtail.vim
@@ -15,8 +15,6 @@ if !g:coqtail_supported
   finish
 endif
 
-py3 from coqtail import CoqtailServer
-
 " Initialize global variables.
 " Default CoqProject file name.
 if !exists('g:coqtail_project_names')

--- a/plugin/coqtail.vim
+++ b/plugin/coqtail.vim
@@ -7,14 +7,6 @@ let g:loaded_coqtail = 1
 let s:python_dir = expand('<sfile>:p:h:h') . '/python'
 let g:coqtail_supported = coqtail#compat#init(s:python_dir)
 
-if !g:coqtail_supported
-  call coqtail#util#warn(
-        \ "Coqtail requires Python 3.6 or later.\n" .
-        \ 'See https://github.com/whonore/Coqtail/blob/main/README.md#python-2-support.'
-        \)
-  finish
-endif
-
 " Initialize global variables.
 " Default CoqProject file name.
 if !exists('g:coqtail_project_names')

--- a/syntax/coq.vim
+++ b/syntax/coq.vim
@@ -518,80 +518,76 @@ syn sync minlines=50
 syn sync maxlines=500
 
 " Define the default highlighting.
-command -nargs=+ HiLink hi def link <args>
-
 " PROOFS
-HiLink coqTactic            Keyword
-HiLink coqLtac              coqTactic
-HiLink coqProofKwd          coqTactic
-HiLink coqProofPunctuation  coqTactic
-HiLink coqTacticKwd         coqTactic
-HiLink coqTacNotationKwd    coqTactic
-HiLink coqEvalFlag          coqTactic
-HiLink coqEqnKwd            coqTactic
-HiLink coqTacticAdmit       coqProofAdmit
+hi def link coqTactic            Keyword
+hi def link coqLtac              coqTactic
+hi def link coqProofKwd          coqTactic
+hi def link coqProofPunctuation  coqTactic
+hi def link coqTacticKwd         coqTactic
+hi def link coqTacNotationKwd    coqTactic
+hi def link coqEvalFlag          coqTactic
+hi def link coqEqnKwd            coqTactic
+hi def link coqTacticAdmit       coqProofAdmit
 " Exception
-HiLink coqProofDot          coqVernacular
+hi def link coqProofDot          coqVernacular
 
 " PROOF DELIMITERS ("Proof", "Qed", "Defined", "Save")
-HiLink coqProofDelim        Underlined
+hi def link coqProofDelim        Underlined
 
 " TERMS AND TYPES
-HiLink coqTerm              Type
-HiLink coqKwd               coqTerm
-HiLink coqTermPunctuation   coqTerm
+hi def link coqTerm              Type
+hi def link coqKwd               coqTerm
+hi def link coqTermPunctuation   coqTerm
 
 " VERNACULAR COMMANDS
-HiLink coqVernacular        PreProc
-HiLink coqVernacCmd         coqVernacular
-HiLink coqVernacPunctuation coqVernacular
-HiLink coqHint              coqVernacular
-HiLink coqFeedback          coqVernacular
-HiLink coqTopLevel          coqVernacular
-HiLink coqRegisterKwd       coqVernacular
+hi def link coqVernacular        PreProc
+hi def link coqVernacCmd         coqVernacular
+hi def link coqVernacPunctuation coqVernacular
+hi def link coqHint              coqVernacular
+hi def link coqFeedback          coqVernacular
+hi def link coqTopLevel          coqVernacular
+hi def link coqRegisterKwd       coqVernacular
 
 " DEFINED OBJECTS
-HiLink coqIdent             Identifier
-HiLink coqNotationString    coqIdent
+hi def link coqIdent             Identifier
+hi def link coqNotationString    coqIdent
 
 " CONSTRUCTORS AND FIELDS
-HiLink coqConstructor       Keyword
-HiLink coqField             coqConstructor
+hi def link coqConstructor       Keyword
+hi def link coqField             coqConstructor
 
 " NOTATION SPECIFIC ("at level", "format", etc)
-HiLink coqNotationKwd       Special
-HiLink coqEqnOptions        coqNotationKwd
+hi def link coqNotationKwd       Special
+hi def link coqEqnOptions        coqNotationKwd
 
 " ATTRIBUTES
-HiLink coqAttribute         coqVernacular
-HiLink coqAttrBool          Boolean
-HiLink coqAttrPunc          coqAttribute
+hi def link coqAttribute         coqVernacular
+hi def link coqAttrBool          Boolean
+hi def link coqAttrPunc          coqAttribute
 
 " USUAL VIM HIGHLIGHTINGS
 " Comments
-HiLink coqComment           Comment
-HiLink coqProofComment      coqComment
+hi def link coqComment           Comment
+hi def link coqProofComment      coqComment
 
 " Todo
-HiLink coqTodo              Todo
+hi def link coqTodo              Todo
 
 " Errors
-HiLink coqError             Error
-HiLink coqProofAdmit        coqError
+hi def link coqError             Error
+hi def link coqProofAdmit        coqError
 
 " Strings
-HiLink coqString            String
+hi def link coqString            String
 
 " Elpi
-HiLink elpiKeyword          Keyword
-HiLink elpiMetavar          Identifier
-HiLink elpiComment          Comment
-HiLink elpiString           String
-HiLink elpiSymbol           Operator
-HiLink elpiMode             Special
-HiLink elpiNumber           Number
-HiLink elpiPunctuation      Type
-
-delcommand HiLink
+hi def link elpiKeyword          Keyword
+hi def link elpiMetavar          Identifier
+hi def link elpiComment          Comment
+hi def link elpiString           String
+hi def link elpiSymbol           Operator
+hi def link elpiMode             Special
+hi def link elpiNumber           Number
+hi def link elpiPunctuation      Type
 
 let b:current_syntax = 'coq'


### PR DESCRIPTION
To improve startup time `CoqtailServer` should be imported only when it is needed.
This makes initialization 2x faster (even if it's in the order of ms, on slower machines you can notice the delay). 