### PR TITLE
Parse comments in _CoqProject files correctly

### DIFF
--- a/autoload/coqtail/coqproject.vim
+++ b/autoload/coqtail/coqproject.vim
@@ -40,6 +40,7 @@ function! s:parse_string(s) abort
       break
     elseif l:c ==# '#'
       let l:s = s:parse_skip_comment(l:s)
+      break
     else
       let l:buf .= l:c
     endif

--- a/tests/vim/coq_project.vader
+++ b/tests/vim/coq_project.vader
@@ -186,3 +186,9 @@ Execute (ignore-comments):
   call writefile(['# abc', '-arg a', '# def', '-arg b', '# ghi'], f)
   let args = coqtail#coqproject#parse(f)
   AssertEqual ['a', 'b'], args
+
+Execute (comment-in-unquoted-string):
+  let f = tempname()
+  call writefile(['-arg a#b', '-arg c'], f)
+  let args = coqtail#coqproject#parse(f)
+  AssertEqual ['a', 'c'], args


### PR DESCRIPTION
This fixes a bug in how comments are handled if they do not have any whitespace before the #.