### PR TITLE
Fix E108 in 'joinspaces' autocommand

### DIFF
--- a/ftplugin/coq.vim
+++ b/ftplugin/coq.vim
@@ -124,5 +124,5 @@ augroup CoqtailJoinspaces
 
   autocmd BufLeave <buffer>
         \ let &joinspaces = get(b:, '_coqtail_save_js', 1)
-        \ | unlet b:_coqtail_save_js
+        \ | unlet! b:_coqtail_save_js
 augroup END


### PR DESCRIPTION
The `joinspaces` `BufLeave` autocommand unconditionally `unlet`s `b:_coqtail_save_js`, but `BufEnter` only sets it behind an `if !exists()` guard (added in #424). When `BufLeave` fires without a matching `BufEnter`, e.g. another plugin moving window focus over a `.v` buffer (snacks.nvim's picker, in my case), the `unlet` throws `E108`. `unlet!` mirrors the guard already on the `let`.

Repro:
```vim
:edit foo.v
:doautocmd BufLeave " clears b:_coqtail_save_js
:doautocmd BufLeave " E108
```
