### PR TITLE
Set 'path' and add fallback for 'includeexpr'

### DIFF
--- a/autoload/coqtail.vim
+++ b/autoload/coqtail.vim
@@ -12,10 +12,18 @@ let s:unsupported_msg =
 " Server port.
 let s:port = -1
 
-" Find the path corresponding to 'lib'. Used by includeexpr.
-function! coqtail#findlib(lib) abort
-  let [l:ok, l:lib] = s:call('find_lib', 'sync', 0, {'lib': a:lib})
-  return (l:ok && l:lib != v:null) ? l:lib : a:lib
+" Find an included library.
+" WARNING: For performance reasons this function uses 'v:fname' and it only
+" works when evaluating 'includeexpr'.
+function! coqtail#includeexpr() abort
+  " First, try asking Rocq
+  let [l:ok, l:lib] = s:call('find_lib', 'sync', 0, {'lib': v:fname})
+  if l:ok && l:lib != v:null
+    return l:lib
+  endif
+  " otherwise, fallback to searching the filename in &path.
+  let l:lib = tr(v:fname, '.', '/')
+  return substitute(l:lib, '\v\C^(Corelib|Coq)/', '', '')
 endfunction
 
 " Find the start of the nth goal.

--- a/autoload/coqtail/util.vim
+++ b/autoload/coqtail/util.vim
@@ -191,3 +191,21 @@ function! coqtail#util#pushtagstack(item) abort
     call settagstack(l:winid, l:tagstack, l:action)
   endif
 endfunction
+
+" Get the path to Rocq's libraries
+function! coqtail#util#getpath() abort
+  let l:paths = map(systemlist('coqidetop -where'), 'trim(v:val)')
+  let l:path = '.'
+
+  if !v:shell_error && !empty(l:paths)
+    let l:prefix = l:paths[0]
+    let l:libs = [
+          \ l:prefix . '/theories/**',
+          \ l:prefix . '/user-contrib/**'
+          \ ]
+    let l:path .= ',' . join(l:libs, ',')
+  endif
+
+  let l:path .= ',,'
+  return l:path
+endfunction

--- a/autoload/coqtail/util.vim
+++ b/autoload/coqtail/util.vim
@@ -204,11 +204,11 @@ endfunction
 " Get Rocq executable name
 function! coqtail#util#rocq_name() abort
   try
+    let l:coq_path = expand(coqtail#util#getvar([b:, g:], 'coqtail_coq_path', $COQBIN))
+    let l:coq_prog = coqtail#util#getvar([b:, g:], 'coqtail_coq_prog', '')
+
     py3 import xmlInterface
-    return py3eval('xmlInterface.find_coq(coq_path or None, coq_prog or None)', {
-          \ 'coq_path': expand(coqtail#util#getvar([b:, g:], 'coqtail_coq_path', $COQBIN)),
-          \ 'coq_prog': coqtail#util#getvar([b:, g:], 'coqtail_coq_prog', '')
-          \ })
+    return py3eval(printf('xmlInterface.find_coq("%s" or None, "%s" or None)', l:coq_path, l:coq_prog))
   catch
     return ''
   endtry

--- a/autoload/coqtail/util.vim
+++ b/autoload/coqtail/util.vim
@@ -201,18 +201,35 @@ function! s:trim(x) abort
   endif
 endfunction
 
+" Get Rocq executable name
+function! coqtail#util#rocq_name() abort
+  try
+    py3 import xmlInterface
+    return py3eval('xmlInterface.find_coq(coq_path or None, coq_prog or None)', {
+          \ 'coq_path': expand(coqtail#util#getvar([b:, g:], 'coqtail_coq_path', $COQBIN)),
+          \ 'coq_prog': coqtail#util#getvar([b:, g:], 'coqtail_coq_prog', '')
+          \ })
+  catch
+    return ''
+  endtry
+endfunction
+
 " Get the path to Rocq's libraries
 function! coqtail#util#getpath() abort
-  let l:paths = map(systemlist('coqidetop -where'), 's:trim(v:val)')
   let l:path = '.'
+  let l:rocq = coqtail#util#rocq_name()
 
-  if !v:shell_error && !empty(l:paths)
-    let l:prefix = l:paths[0]
-    let l:libs = [
-          \ l:prefix . '/theories/**',
-          \ l:prefix . '/user-contrib/**'
-          \ ]
-    let l:path .= ',' . join(l:libs, ',')
+  if !empty(l:rocq)
+    let l:paths = map(systemlist($"{l:rocq} -where"), 's:trim(v:val)')
+
+    if !v:shell_error && !empty(l:paths)
+      let l:prefix = l:paths[0]
+      let l:libs = [
+            \ l:prefix . '/theories/**',
+            \ l:prefix . '/user-contrib/**'
+            \ ]
+      let l:path .= ',' . join(l:libs, ',')
+    endif
   endif
 
   let l:path .= ',,'

--- a/autoload/coqtail/util.vim
+++ b/autoload/coqtail/util.vim
@@ -192,15 +192,6 @@ function! coqtail#util#pushtagstack(item) abort
   endif
 endfunction
 
-" For older Vim versions that don't have trim()
-function! s:trim(x) abort
-  if has('patch-8.0.1630')
-    return trim(a:x)
-  else
-    return substitute(a:x, '^\s*\(.\{-}\)\s*$', '\1', '')
-  endif
-endfunction
-
 " Get Rocq executable name
 function! coqtail#util#rocq_name() abort
   try
@@ -220,13 +211,13 @@ function! coqtail#util#getpath() abort
   let l:rocq = coqtail#util#rocq_name()
 
   if !empty(l:rocq)
-    let l:paths = map(systemlist($"{l:rocq} -where"), 's:trim(v:val)')
+    let l:cmd = l:rocq . ' -where'
+    let l:dir = substitute(system(l:cmd), '\v\s|\n', '', 'g')
 
-    if !v:shell_error && !empty(l:paths)
-      let l:prefix = l:paths[0]
+    if !v:shell_error && !empty(l:dir)
       let l:libs = [
-            \ l:prefix . '/theories/**',
-            \ l:prefix . '/user-contrib/**'
+            \ l:dir . '/theories/**',
+            \ l:dir . '/user-contrib/**'
             \ ]
       let l:path .= ',' . join(l:libs, ',')
     endif

--- a/autoload/coqtail/util.vim
+++ b/autoload/coqtail/util.vim
@@ -208,7 +208,7 @@ function! coqtail#util#rocq_name() abort
     let l:coq_prog = coqtail#util#getvar([b:, g:], 'coqtail_coq_prog', '')
 
     py3 import xmlInterface
-    return py3eval($"xmlInterface.find_coq('{l:coq_path}' or None, '{l:coq_prog}' or None)")
+    return py3eval(printf('xmlInterface.find_coq("%s" or None, "%s" or None)', l:coq_path, l:coq_prog))
   catch
     return ''
   endtry

--- a/autoload/coqtail/util.vim
+++ b/autoload/coqtail/util.vim
@@ -208,7 +208,7 @@ function! coqtail#util#rocq_name() abort
     let l:coq_prog = coqtail#util#getvar([b:, g:], 'coqtail_coq_prog', '')
 
     py3 import xmlInterface
-    return py3eval(printf('xmlInterface.find_coq("%s" or None, "%s" or None)', l:coq_path, l:coq_prog))
+    return py3eval($"xmlInterface.find_coq('{l:coq_path}' or None, '{l:coq_prog}' or None)")
   catch
     return ''
   endtry

--- a/autoload/coqtail/util.vim
+++ b/autoload/coqtail/util.vim
@@ -192,9 +192,18 @@ function! coqtail#util#pushtagstack(item) abort
   endif
 endfunction
 
+" For older Vim versions that don't have trim()
+function! s:trim(x) abort
+  if has('patch-8.0.1630')
+    return trim(a:x)
+  else
+    return substitute(a:x, '^\s*\(.\{-}\)\s*$', '\1', '')
+  endif
+endfunction
+
 " Get the path to Rocq's libraries
 function! coqtail#util#getpath() abort
-  let l:paths = map(systemlist('coqidetop -where'), 'trim(v:val)')
+  let l:paths = map(systemlist('coqidetop -where'), 's:trim(v:val)')
   let l:path = '.'
 
   if !v:shell_error && !empty(l:paths)

--- a/ftplugin/coq.vim
+++ b/ftplugin/coq.vim
@@ -19,11 +19,13 @@ if g:coqtail_supported
   call coqtail#register()
 endif
 
+" Set 'path" to Rocq's library location
+let &l:path = coqtail#util#getpath()
+let b:undo_ftplugin .= ' | setl pa<'
+
 " Follow imports
-if g:coqtail_supported
-  setlocal includeexpr=coqtail#findlib(v:fname)
-  let b:undo_ftplugin .= ' | setl inex<'
-endif
+setlocal includeexpr=coqtail#includeexpr()
+let b:undo_ftplugin .= ' | setl inex<'
 
 " Comments
 if has('comments')

--- a/ftplugin/coq.vim
+++ b/ftplugin/coq.vim
@@ -3,8 +3,16 @@ if exists('b:did_ftplugin')
   finish
 endif
 let b:did_ftplugin = 1
+let b:undo_ftplugin = ''
 
-if !g:coqtail_supported
+if g:coqtail_supported
+  " Initialize buffer local variables, commands, and mappings.
+  call coqtail#register()
+
+  " Set 'path" to Rocq's library location
+  let &l:path = coqtail#util#getpath()
+  let b:undo_ftplugin .= ' | setl pa<'
+else
   call coqtail#util#warn(
         \ "Coqtail requires Python 3.6 or later.\n" .
         \ 'See https://github.com/whonore/Coqtail/blob/main/README.md#python-2-support.'
@@ -13,15 +21,7 @@ endif
 
 setlocal suffixesadd=.v
 setlocal include=\\<Require\\>\\(\\_s*\\(Import\\\|Export\\)\\>\\)\\?
-let b:undo_ftplugin = 'setl sua< inc<'
-
-if g:coqtail_supported
-  call coqtail#register()
-endif
-
-" Set 'path" to Rocq's library location
-let &l:path = coqtail#util#getpath()
-let b:undo_ftplugin .= ' | setl pa<'
+let b:undo_ftplugin .= 'setl sua< inc<'
 
 " Follow imports
 setlocal includeexpr=coqtail#includeexpr()

--- a/ftplugin/coq.vim
+++ b/ftplugin/coq.vim
@@ -3,7 +3,6 @@ if exists('b:did_ftplugin')
   finish
 endif
 let b:did_ftplugin = 1
-let b:undo_ftplugin = ''
 
 if g:coqtail_supported
   " Initialize buffer local variables, commands, and mappings.
@@ -11,17 +10,20 @@ if g:coqtail_supported
 
   " Set 'path" to Rocq's library location
   let &l:path = coqtail#util#getpath()
-  let b:undo_ftplugin .= ' | setl pa<'
 else
   call coqtail#util#warn(
         \ "Coqtail requires Python 3.6 or later.\n" .
         \ 'See https://github.com/whonore/Coqtail/blob/main/README.md#python-2-support.'
         \)
+
+  setlocal path-=/usr/include
 endif
+
+let b:undo_ftplugin = 'setl pa<'
 
 setlocal suffixesadd=.v
 setlocal include=\\<Require\\>\\(\\_s*\\(Import\\\|Export\\)\\>\\)\\?
-let b:undo_ftplugin .= 'setl sua< inc<'
+let b:undo_ftplugin .= ' | setl sua< inc<'
 
 " Follow imports
 setlocal includeexpr=coqtail#includeexpr()

--- a/tests/unit/test_find_coq.py
+++ b/tests/unit/test_find_coq.py
@@ -1,0 +1,39 @@
+"""Roqc executable resolution unit tests."""
+
+import os
+from pathlib import Path
+
+from xmlInterface import find_coq
+
+
+def mock_rocq_exe(name: str, path: Path, *, set_path: bool = False) -> Path:
+    """Create a fake Rocq executable."""
+    exe = path / name
+    exe.touch(mode=0o777)
+    if set_path:
+        os.environ["PATH"] = f"{path}"
+    return exe
+
+
+def test_coqc_path(tmp_path: Path) -> None:
+    """Default to coqc if it's found on $PATH."""
+    exe = mock_rocq_exe("coqc", tmp_path, set_path=True)
+    assert find_coq(None, None) == str(exe)
+
+
+def test_rocq_path(tmp_path: Path) -> None:
+    """Default to rocq if it's found on $PATH."""
+    exe = mock_rocq_exe("rocq", tmp_path, set_path=True)
+    assert find_coq(None, None) == str(exe)
+
+
+def test_override_path(tmp_path: Path) -> None:
+    """Search `coq_path` instead of $PATH if provided."""
+    exe = mock_rocq_exe("rocq", tmp_path)
+    assert find_coq(str(tmp_path), None) == str(exe)
+
+
+def test_override_prog(tmp_path: Path) -> None:
+    """Search for `coq_prog` if provided."""
+    exe = mock_rocq_exe("my-rocq", tmp_path, set_path=True)
+    assert find_coq(None, "my-rocq") == str(exe)


### PR DESCRIPTION
Until the server is started the command `gf` and insert-mode completion for
included files don't work, so I changed `&path` to point to Rocq's libraries
directories and added a fallback to `&includeexpr` when the query to Rocq
fails.

One small caveat is that for `gf` the filename is first searched in `&path` and
if it can't be found it is modified with `&includeexpr` and another search is
done, so (in theory) it may be possible that the file opened by `gf` is not the
same one found by Rocq (`&includeexpr` is always used on the files found with
`&include`).
I don't think it's a big issue but remapping `gf` is a simple solution.