### PR TITLE
Fix bug when selecting indented proof blocks

### DIFF
--- a/autoload/coqtail/search.vim
+++ b/autoload/coqtail/search.vim
@@ -32,8 +32,10 @@ function! s:search_count(pattern, flags, count, visual) abort
   endfor
 endfunction
 
-function! s:find_proof_block() abort
+function! s:find_range() abort
   let block = searchpairpos(s:proofstart_pattern, '', s:proofend_pattern, 'cW')
+  let origpos = getpos('.')
+
   if block == [0, 0]
     call search(s:proofstart_pattern, 'cW')
     let start = getpos('.')
@@ -44,26 +46,28 @@ function! s:find_proof_block() abort
     call search(s:proofstart_pattern, 'bW')
     let start = getpos('.')
   endif
+
+  call setpos('.', origpos)
   return [start, end]
 endfunction
 
-function! coqtail#search#select_i() abort
-  let [start, end] = s:find_proof_block()
+function! s:select_i() abort
+  let [start, end] = s:find_range()
   let start_max_col = match(getline(start[1]), '^[^.]\+\.\zs', start[2]) + 1
 
   " For indented proof blocks find the first non-whitespace character
   let start_first_col = match(getline(start[1]), '\S') + 1
   let end_first_col = match(getline(end[1]), '\S') + 1
 
-  if start[1] != end[1] && start[2] == start_first_col && end[2] == end_first_col && start_max_col == col([start[1], '$'])
+  if end[1] - start[1] > 1
+        \ && end[2] == end_first_col
+        \ && start_max_col == col([start[1], '$'])
     let start[1] += 1
     let start[2]  = start_first_col
     let end[1]   -= 1
     let end[2]    = end_first_col
 
-    call setpos('.', start)
-    normal! V
-    call setpos('.', end)
+    return ['V', start, end]
   else
     if start_max_col == col([start[1], '$'])
       let start[1] += 1
@@ -79,26 +83,43 @@ function! coqtail#search#select_i() abort
       let end[2] -= 1
     endif
 
-    call setpos('.', start)
-    normal! v
-    call setpos('.', end)
+    if start[1] > end[1] || (start[1] == end[1] && start[2] >= end[2])
+      return 0
+    endif
+
+    return ['v', start, end]
   endif
 endfunction
 
-function! coqtail#search#select_a() abort
-  let [start, end] = s:find_proof_block()
+function! s:select_a() abort
+  let [start, end] = s:find_range()
   let end_max_col = match(getline(end[1]), '^[^.]\+\.\zs', end[2]) + 1
 
   " For indented proof blocks find the first non-whitespace character
   let start_first_col = match(getline(start[1]), '\S') + 1
   let end_first_col = match(getline(end[1]), '\S') + 1
 
-  call setpos('.', start)
   if start[2] > start_first_col || end[2] > end_first_col || end_max_col != col([end[1], '$'])
     let end[2] = end_max_col
-    normal! v
+    return ['v', start, end]
   else
-    normal! V
+    return ['V', start, end]
   endif
-  call setpos('.', end)
+endfunction
+
+function! s:select_wrapper(args) abort
+  if type(a:args) == type([]) && len(a:args) == 3
+    let [visual, start, end] = a:args
+    call setpos('.', start)
+    exe 'normal! ' . visual
+    call setpos('.', end)
+  endif
+endfunction
+
+function! coqtail#search#select_i() abort
+  return s:select_wrapper(s:select_i())
+endfunction
+
+function! coqtail#search#select_a() abort
+  return s:select_wrapper(s:select_a())
 endfunction

--- a/autoload/coqtail/search.vim
+++ b/autoload/coqtail/search.vim
@@ -51,11 +51,15 @@ function! coqtail#search#select_i() abort
   let [start, end] = s:find_proof_block()
   let start_max_col = match(getline(start[1]), '^[^.]\+\.\zs', start[2]) + 1
 
-  if start[1] != end[1] && start[2] == 1 && end[2] == 1 && start_max_col == col([start[1], '$'])
+  " For indented proof blocks find the first non-whitespace character
+  let start_first_col = match(getline(start[1]), '\S') + 1
+  let end_first_col = match(getline(end[1]), '\S') + 1
+
+  if start[1] != end[1] && start[2] == start_first_col && end[2] == end_first_col && start_max_col == col([start[1], '$'])
     let start[1] += 1
-    let start[2]  = 0
+    let start[2]  = start_first_col
     let end[1]   -= 1
-    let end[2]    = 0
+    let end[2]    = end_first_col
 
     call setpos('.', start)
     normal! V
@@ -63,12 +67,12 @@ function! coqtail#search#select_i() abort
   else
     if start_max_col == col([start[1], '$'])
       let start[1] += 1
-      let start[2]  = 0
+      let start[2]  = start_first_col
     else
       let start[2] = start_max_col
     endif
 
-    if end[2] == 1
+    if end[2] == end_first_col
       let end[1] -= 1
       let end[2]  = col([end[1], '$'])
     else
@@ -85,8 +89,12 @@ function! coqtail#search#select_a() abort
   let [start, end] = s:find_proof_block()
   let end_max_col = match(getline(end[1]), '^[^.]\+\.\zs', end[2]) + 1
 
+  " For indented proof blocks find the first non-whitespace character
+  let start_first_col = match(getline(start[1]), '\S') + 1
+  let end_first_col = match(getline(end[1]), '\S') + 1
+
   call setpos('.', start)
-  if start[2] > 1 || end[2] > 1 || end_max_col != col([end[1], '$'])
+  if start[2] > start_first_col || end[2] > end_first_col || end_max_col != col([end[1], '$'])
     let end[2] = end_max_col
     normal! v
   else

--- a/tests/vim/proof_textobj.vader
+++ b/tests/vim/proof_textobj.vader
@@ -1,0 +1,120 @@
+" Tests for the proof text object
+
+Given coq (own-line-i):
+  Goal True.
+  Proof.
+    auto.
+    auto.
+    auto. auto. auto.
+    auto.
+  Qed.
+
+Do (own-line-i):
+  diP
+
+Expect coq (own-line-i):
+  Goal True.
+  Proof.
+  Qed.
+
+Given coq (own-line-a):
+  Goal True.
+  Proof.
+    auto.
+  Qed.
+
+Do (own-line-a):
+  daP
+
+Expect coq (own-line-a):
+  Goal True.
+
+Given coq (mixed-change-i):
+  Goal True. Proof.
+    auto.
+  Qed.
+
+Do (mixed-change-i):
+  ciP
+
+Expect coq (mixed-change-i):
+  Goal True. Proof.
+
+  Qed.
+
+Given coq (mixed-a):
+  Goal True. Proof.
+    auto.
+  Qed.
+
+Do (mixed-a):
+  daP
+
+Expect coq (mixed-a):
+  Goal True. 
+
+Given coq (inline-c-i):
+  Goal True. Proof. auto. Qed.
+
+Do (inline-c-i):
+  ciP
+
+Expect coq (inline-c-i):
+  Goal True. Proof.Qed.
+
+Given coq (inline-c-a):
+  Goal True. Proof. auto. Qed.
+
+Do (inline-c-a):
+  caP
+
+Expect coq (inline-c-a):
+  Goal True. 
+
+Given coq (inline2-c-a):
+  Goal True.
+  Proof.
+  auto. Qed.
+
+Do (inline2-c-a):
+  ciP
+
+Expect coq (inline2-c-a):
+  Goal True.
+  Proof.
+  Qed.
+
+Given coq (inline-after-proof):
+  Goal True.
+  Proof. auto.
+  Qed.
+
+Do (inline-after-proof):
+  ciP
+
+Expect coq (inline-after-proof):
+  Goal True.
+  Proof.Qed.
+
+Given coq (inline-mixed):
+  Goal True. Proof. auto.
+  auto. Qed.
+
+Do (inline-mixed):
+  ciP
+
+Expect coq (inline-mixed):
+  Goal True. Proof.Qed.
+
+Given coq (empty):
+  Goal True.
+  Proof.
+  Qed.
+
+Do (empty):
+  diP
+
+Expect coq (empty):
+  Goal True.
+  Proof.
+  Qed.


### PR DESCRIPTION
The old code didn't handle the case where the proof block is indented. Maybe we should add tests for this?